### PR TITLE
添加对socket.io服务路径path的支持/Add support for socket.io path

### DIFF
--- a/SocketIOClient.Sample/SocketIOClient.Sample.csproj
+++ b/SocketIOClient.Sample/SocketIOClient.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/SocketIOClient.Test/SocketIOClient.Test.csproj
+++ b/SocketIOClient.Test/SocketIOClient.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SocketIOClient.Test/SocketIOTest.cs
+++ b/SocketIOClient.Test/SocketIOTest.cs
@@ -415,5 +415,23 @@ namespace SocketIOClient.Test
             Assert.IsTrue(result);
             Assert.AreEqual("Authentication error -- Ns", resText);
         }
+
+        [TestMethod]
+        public async Task EmitStringWithPathTest()
+        {
+            var client = new SocketIO("http://localhost:3001")
+            {
+                Path = "/test"
+            };
+            string guid = Guid.NewGuid().ToString();
+            client.On("test", async res =>
+            {
+                Assert.AreEqual(guid + " - server", res.Text);
+                await client.CloseAsync();
+            });
+            await client.ConnectAsync();
+            await Task.Delay(1000);
+            await client.EmitAsync("test", guid);
+        }
     }
 }

--- a/SocketIOClient.Test/UrlConverterTest.cs
+++ b/SocketIOClient.Test/UrlConverterTest.cs
@@ -12,7 +12,7 @@ namespace SocketIOClient.Test
         {
             var urlConverter = new UrlConverter();
             Uri httpUri = new Uri("http://localhost:3000");
-            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null);
+            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null, null);
 
             Assert.AreEqual("ws://localhost:3000/socket.io/?EIO=eio&transport=websocket", wsUri.ToString());
         }
@@ -22,7 +22,7 @@ namespace SocketIOClient.Test
         {
             var urlConverter = new UrlConverter();
             Uri httpUri = new Uri("https://localhost:3000");
-            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null);
+            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null, null);
 
             Assert.AreEqual("wss://localhost:3000/socket.io/?EIO=eio&transport=websocket", wsUri.ToString());
         }
@@ -32,7 +32,7 @@ namespace SocketIOClient.Test
         {
             var urlConverter = new UrlConverter();
             Uri httpUri = new Uri("http://localhost");
-            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null);
+            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null, null);
 
             Assert.AreEqual("ws://localhost/socket.io/?EIO=eio&transport=websocket", wsUri.ToString());
         }
@@ -42,7 +42,7 @@ namespace SocketIOClient.Test
         {
             var urlConverter = new UrlConverter();
             Uri httpUri = new Uri("https://localhost");
-            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null);
+            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null, null);
 
             Assert.AreEqual("wss://localhost/socket.io/?EIO=eio&transport=websocket", wsUri.ToString());
         }
@@ -52,13 +52,27 @@ namespace SocketIOClient.Test
         {
             var urlConverter = new UrlConverter();
             Uri httpUri = new Uri("https://localhost");
-            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", new Dictionary<string, string>
+            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", null, new Dictionary<string, string>
             {
                 { "uid", "abc" },
                 { "pwd", "123" }
             });
 
             Assert.AreEqual("wss://localhost/socket.io/?EIO=eio&transport=websocket&uid=abc&pwd=123", wsUri.ToString());
+        }
+
+        [TestMethod]
+        public void CustomPathTest()
+        {
+            var urlConverter = new UrlConverter();
+            Uri httpUri = new Uri("https://localhost");
+            Uri wsUri = urlConverter.HttpToWs(httpUri, "eio", "/test", new Dictionary<string, string>
+            {
+                { "uid", "abc" },
+                { "pwd", "123" }
+            });
+
+            Assert.AreEqual("wss://localhost/test/?EIO=eio&transport=websocket&uid=abc&pwd=123", wsUri.ToString());
         }
     }
 }

--- a/SocketIOClient/SocketIO.cs
+++ b/SocketIOClient/SocketIO.cs
@@ -13,17 +13,27 @@ namespace SocketIOClient
     public class SocketIO
     {
         /// <summary>
-        /// 
+        /// Options 1: http://example.com/subpath + /socket.io + /sionamespace + ture
+        /// Options 2: http://example.com/sionamespace + param path unuse + param sionamespace unuse + ture
         /// </summary>
-        /// <param name="uri">HTTP(s)服务地址，结尾不需要斜杠。例如：https://example.com/subpath</param>
+        /// <param name="uri">新版：HTTP(s)服务地址，结尾不需要斜杠。例如：https://example.com/subpath。旧版：http://example.com/sionamespace</param>
         /// <param name="path">Socket.io服务路径。socket.io在服务端的参数path，默认为/socket.io。例如：/subpath/which/provide/socket/io/service。参考https://socket.io/docs/server-api/</param>
-        /// <param name="sionamespace">命名空间，参考https://socket.io/docs/rooms-and-namespaces/</param>
-        public SocketIO(Uri uri, string path, string sionamespace)
+        /// <param name="sionamespace">命名空间，若不使用传入空字符串即可。参考https://socket.io/docs/rooms-and-namespaces/</param>
+        /// <param name="usePath">兼容选项，false时兼容旧版本</param>
+        public SocketIO(Uri uri, string path, string sionamespace, bool usePath)
         {
 
             if (uri.Scheme == "https" || uri.Scheme == "http" || uri.Scheme == "wss" || uri.Scheme == "ws")
             {
-                _uri = new Uri(uri.AbsoluteUri + path);
+                // uri = http://example.com:1234/sionamespace
+                // path = /path
+                // uri.Scheme = http
+                // uri.Authority = example.com:1234
+                // _uri = http://example.com:1234/path
+                if (!usePath)
+                    _uri = new Uri(uri.Scheme + "://" + uri.Authority + path);
+                else
+                    _uri = new Uri(uri.AbsoluteUri + path);
             }
             else
             {
@@ -33,16 +43,70 @@ namespace SocketIOClient
             Callbacks = new Dictionary<int, EventHandler>();
             _urlConverter = new UrlConverter();
 
-            if (sionamespace.Length > 0)
+            if (!usePath)
+            {
+                if (uri.AbsolutePath != "/")
+                    _namespace = uri.AbsolutePath + ',';
+            }
+            else if (sionamespace.Length > 0)
             {
                 _namespace = sionamespace + ',';
             }
+
             _packetId = -1;
             ConnectTimeout = TimeSpan.FromSeconds(30);
         }
 
-        public SocketIO(string uri) : this(new Uri(uri), "/socket.io", "") { }
-        public SocketIO(string uri, string path) : this(new Uri(uri), path, "") { }
+        /// <summary>
+        /// http://example.com/sionamespace
+        /// </summary>
+        /// <param name="uri">http://example.com/sionamespace</param>
+        public SocketIO(string uri) : this(new Uri(uri)) { }
+        /// <summary>
+        /// http://example.com/sionamespace
+        /// </summary>
+        /// <param name="uri">http://example.com/sionamespace</param>
+        public SocketIO(Uri uri) : this(uri, false) { }
+        /// <summary>
+        ///  Options 1: http://example.com/sionamespace + false
+        ///  Options 2: http://example.com/subpath + true
+        /// </summary>
+        /// <param name="uri">http://example.com/sionamespace or http://example.com/subpath</param>
+        /// <param name="usePath">false or true</param>
+        public SocketIO(string uri, bool usePath) : this(new Uri(uri), usePath) { }
+        /// <summary>
+        ///  Options 1: http://example.com/sionamespace + false
+        ///  Options 2: http://example.com/subpath + true
+        /// </summary>
+        /// <param name="uri">http://example.com/sionamespace or http://example.com/subpath</param>
+        /// <param name="usePath">false or true</param>
+        public SocketIO(Uri uri, bool usePath) : this(uri, "/socket.io", "", usePath) { }
+        /// <summary>
+        /// http://example.com/subpath + /sionamespace
+        /// </summary>
+        /// <param name="uri">http://example.com/subpath</param>
+        /// <param name="sionamespace">/sionamespace</param>
+        public SocketIO(string uri, string sionamespace) : this(new Uri(uri), sionamespace) { }
+        /// <summary>
+        /// http://example.com/subpath + /sionamespace
+        /// </summary>
+        /// <param name="uri">http://example.com/subpath</param>
+        /// <param name="sionamespace">/sionamespace</param>
+        public SocketIO(Uri uri, string sionamespace) : this(uri, "/socket.io", sionamespace, true) { }
+        /// <summary>
+        /// http://example.com/subpath + /socket.io + /sionamespace
+        /// </summary>
+        /// <param name="uri">http://example.com/subpath</param>
+        /// <param name="path">/socket.io</param>
+        /// <param name="sionamespace">/sionamespace</param>
+        public SocketIO(string uri, string path, string sionamespace) : this(new Uri(uri), path, sionamespace, true) { }
+        /// <summary>
+        /// http://example.com/subpath + /socket.io + /sionamespace
+        /// </summary>
+        /// <param name="uri">http://example.com/subpath</param>
+        /// <param name="path">/socket.io</param>
+        /// <param name="sionamespace">/sionamespace</param>
+        public SocketIO(Uri uri, string path, string sionamespace) : this(uri, path, sionamespace, true) { }
 
         private const int ReceiveChunkSize = 1024;
         private const int SendChunkSize = 1024;

--- a/SocketIOClient/SocketIO.cs
+++ b/SocketIOClient/SocketIO.cs
@@ -13,27 +13,17 @@ namespace SocketIOClient
     public class SocketIO
     {
         /// <summary>
-        /// Options 1: http://example.com/subpath + /socket.io + /sionamespace + ture
-        /// Options 2: http://example.com/sionamespace + param path unuse + param sionamespace unuse + ture
+        /// 
         /// </summary>
-        /// <param name="uri">新版：HTTP(s)服务地址，结尾不需要斜杠。例如：https://example.com/subpath。旧版：http://example.com/sionamespace</param>
+        /// <param name="uri">HTTP(s)服务地址，结尾不需要斜杠。例如：https://example.com/subpath</param>
         /// <param name="path">Socket.io服务路径。socket.io在服务端的参数path，默认为/socket.io。例如：/subpath/which/provide/socket/io/service。参考https://socket.io/docs/server-api/</param>
-        /// <param name="sionamespace">命名空间，若不使用传入空字符串即可。参考https://socket.io/docs/rooms-and-namespaces/</param>
-        /// <param name="usePath">兼容选项，false时兼容旧版本</param>
-        public SocketIO(Uri uri, string path, string sionamespace, bool usePath)
+        /// <param name="sionamespace">命名空间，参考https://socket.io/docs/rooms-and-namespaces/</param>
+        public SocketIO(Uri uri, string path, string sionamespace)
         {
 
             if (uri.Scheme == "https" || uri.Scheme == "http" || uri.Scheme == "wss" || uri.Scheme == "ws")
             {
-                // uri = http://example.com:1234/sionamespace
-                // path = /path
-                // uri.Scheme = http
-                // uri.Authority = example.com:1234
-                // _uri = http://example.com:1234/path
-                if (!usePath)
-                    _uri = new Uri(uri.Scheme + "://" + uri.Authority + path);
-                else
-                    _uri = new Uri(uri.AbsoluteUri + path);
+                _uri = new Uri(uri.AbsoluteUri + path);
             }
             else
             {
@@ -43,70 +33,16 @@ namespace SocketIOClient
             Callbacks = new Dictionary<int, EventHandler>();
             _urlConverter = new UrlConverter();
 
-            if (!usePath)
-            {
-                if (uri.AbsolutePath != "/")
-                    _namespace = uri.AbsolutePath + ',';
-            }
-            else if (sionamespace.Length > 0)
+            if (sionamespace.Length > 0)
             {
                 _namespace = sionamespace + ',';
             }
-
             _packetId = -1;
             ConnectTimeout = TimeSpan.FromSeconds(30);
         }
 
-        /// <summary>
-        /// http://example.com/sionamespace
-        /// </summary>
-        /// <param name="uri">http://example.com/sionamespace</param>
-        public SocketIO(string uri) : this(new Uri(uri)) { }
-        /// <summary>
-        /// http://example.com/sionamespace
-        /// </summary>
-        /// <param name="uri">http://example.com/sionamespace</param>
-        public SocketIO(Uri uri) : this(uri, false) { }
-        /// <summary>
-        ///  Options 1: http://example.com/sionamespace + false
-        ///  Options 2: http://example.com/subpath + true
-        /// </summary>
-        /// <param name="uri">http://example.com/sionamespace or http://example.com/subpath</param>
-        /// <param name="usePath">false or true</param>
-        public SocketIO(string uri, bool usePath) : this(new Uri(uri), usePath) { }
-        /// <summary>
-        ///  Options 1: http://example.com/sionamespace + false
-        ///  Options 2: http://example.com/subpath + true
-        /// </summary>
-        /// <param name="uri">http://example.com/sionamespace or http://example.com/subpath</param>
-        /// <param name="usePath">false or true</param>
-        public SocketIO(Uri uri, bool usePath) : this(uri, "/socket.io", "", usePath) { }
-        /// <summary>
-        /// http://example.com/subpath + /sionamespace
-        /// </summary>
-        /// <param name="uri">http://example.com/subpath</param>
-        /// <param name="sionamespace">/sionamespace</param>
-        public SocketIO(string uri, string sionamespace) : this(new Uri(uri), sionamespace) { }
-        /// <summary>
-        /// http://example.com/subpath + /sionamespace
-        /// </summary>
-        /// <param name="uri">http://example.com/subpath</param>
-        /// <param name="sionamespace">/sionamespace</param>
-        public SocketIO(Uri uri, string sionamespace) : this(uri, "/socket.io", sionamespace, true) { }
-        /// <summary>
-        /// http://example.com/subpath + /socket.io + /sionamespace
-        /// </summary>
-        /// <param name="uri">http://example.com/subpath</param>
-        /// <param name="path">/socket.io</param>
-        /// <param name="sionamespace">/sionamespace</param>
-        public SocketIO(string uri, string path, string sionamespace) : this(new Uri(uri), path, sionamespace, true) { }
-        /// <summary>
-        /// http://example.com/subpath + /socket.io + /sionamespace
-        /// </summary>
-        /// <param name="uri">http://example.com/subpath</param>
-        /// <param name="path">/socket.io</param>
-        /// <param name="sionamespace">/sionamespace</param>
-        public SocketIO(Uri uri, string path, string sionamespace) : this(uri, path, sionamespace, true) { }
+        public SocketIO(string uri) : this(new Uri(uri), "/socket.io", "") { }
+        public SocketIO(string uri, string path) : this(new Uri(uri), path, "") { }
 
         private const int ReceiveChunkSize = 1024;
         private const int SendChunkSize = 1024;

--- a/SocketIOClient/SocketIO.cs
+++ b/SocketIOClient/SocketIO.cs
@@ -47,6 +47,7 @@ namespace SocketIOClient
         public Dictionary<int, EventHandler> Callbacks { get; }
 
         public int EIO { get; set; } = 3;
+        public string Path { get; set; }
         public TimeSpan ConnectTimeout { get; set; }
         public Dictionary<string, string> Parameters { get; set; }
 
@@ -63,7 +64,7 @@ namespace SocketIOClient
         public Task ConnectAsync()
         {
             _tokenSource = new CancellationTokenSource();
-            Uri wsUri = _urlConverter.HttpToWs(_uri, EIO.ToString(), Parameters);
+            Uri wsUri = _urlConverter.HttpToWs(_uri, EIO.ToString(), Path, Parameters);
             if (_socket != null)
             {
                 _socket.Dispose();

--- a/SocketIOClient/SocketIO.cs
+++ b/SocketIOClient/SocketIO.cs
@@ -12,11 +12,18 @@ namespace SocketIOClient
 {
     public class SocketIO
     {
-        public SocketIO(Uri uri)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="uri">HTTP(s)服务地址，结尾不需要斜杠。例如：https://example.com/subpath</param>
+        /// <param name="path">Socket.io服务路径。socket.io在服务端的参数path，默认为/socket.io。例如：/subpath/which/provide/socket/io/service。参考https://socket.io/docs/server-api/</param>
+        /// <param name="sionamespace">命名空间，参考https://socket.io/docs/rooms-and-namespaces/</param>
+        public SocketIO(Uri uri, string path, string sionamespace)
         {
+
             if (uri.Scheme == "https" || uri.Scheme == "http" || uri.Scheme == "wss" || uri.Scheme == "ws")
             {
-                _uri = uri;
+                _uri = new Uri(uri.AbsoluteUri + path);
             }
             else
             {
@@ -25,15 +32,17 @@ namespace SocketIOClient
             EventHandlers = new Dictionary<string, EventHandler>();
             Callbacks = new Dictionary<int, EventHandler>();
             _urlConverter = new UrlConverter();
-            if (_uri.AbsolutePath != "/")
+
+            if (sionamespace.Length > 0)
             {
-                _namespace = _uri.AbsolutePath + ',';
+                _namespace = sionamespace + ',';
             }
             _packetId = -1;
             ConnectTimeout = TimeSpan.FromSeconds(30);
         }
 
-        public SocketIO(string uri) : this(new Uri(uri)) { }
+        public SocketIO(string uri) : this(new Uri(uri), "/socket.io", "") { }
+        public SocketIO(string uri, string path) : this(new Uri(uri), path, "") { }
 
         private const int ReceiveChunkSize = 1024;
         private const int SendChunkSize = 1024;

--- a/SocketIOClient/SocketIO.cs
+++ b/SocketIOClient/SocketIO.cs
@@ -12,18 +12,11 @@ namespace SocketIOClient
 {
     public class SocketIO
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="uri">HTTP(s)服务地址，结尾不需要斜杠。例如：https://example.com/subpath</param>
-        /// <param name="path">Socket.io服务路径。socket.io在服务端的参数path，默认为/socket.io。例如：/subpath/which/provide/socket/io/service。参考https://socket.io/docs/server-api/</param>
-        /// <param name="sionamespace">命名空间，参考https://socket.io/docs/rooms-and-namespaces/</param>
-        public SocketIO(Uri uri, string path, string sionamespace)
+        public SocketIO(Uri uri)
         {
-
             if (uri.Scheme == "https" || uri.Scheme == "http" || uri.Scheme == "wss" || uri.Scheme == "ws")
             {
-                _uri = new Uri(uri.AbsoluteUri + path);
+                _uri = uri;
             }
             else
             {
@@ -32,17 +25,15 @@ namespace SocketIOClient
             EventHandlers = new Dictionary<string, EventHandler>();
             Callbacks = new Dictionary<int, EventHandler>();
             _urlConverter = new UrlConverter();
-
-            if (sionamespace.Length > 0)
+            if (_uri.AbsolutePath != "/")
             {
-                _namespace = sionamespace + ',';
+                _namespace = _uri.AbsolutePath + ',';
             }
             _packetId = -1;
             ConnectTimeout = TimeSpan.FromSeconds(30);
         }
 
-        public SocketIO(string uri) : this(new Uri(uri), "/socket.io", "") { }
-        public SocketIO(string uri, string path) : this(new Uri(uri), path, "") { }
+        public SocketIO(string uri) : this(new Uri(uri)) { }
 
         private const int ReceiveChunkSize = 1024;
         private const int SendChunkSize = 1024;

--- a/SocketIOClient/UrlConverter.cs
+++ b/SocketIOClient/UrlConverter.cs
@@ -22,8 +22,9 @@ namespace SocketIOClient
             {
                 builder.Append(":").Append(httpUri.Port);
             }
+            builder.Append(httpUri.AbsolutePath);
             builder
-                .Append("/socket.io/?EIO=")
+                .Append("/?EIO=")
                 .Append(eio)
                 .Append("&transport=websocket");
 

--- a/SocketIOClient/UrlConverter.cs
+++ b/SocketIOClient/UrlConverter.cs
@@ -6,7 +6,7 @@ namespace SocketIOClient
 {
     public class UrlConverter
     {
-        public Uri HttpToWs(Uri httpUri, string eio, Dictionary<string, string> parameters)
+        public Uri HttpToWs(Uri httpUri, string eio, string path, Dictionary<string, string> parameters)
         {
             var builder = new StringBuilder();
             if (httpUri.Scheme == "https" || httpUri.Scheme == "wss")
@@ -23,7 +23,8 @@ namespace SocketIOClient
                 builder.Append(":").Append(httpUri.Port);
             }
             builder
-                .Append("/socket.io/?EIO=")
+                .Append(string.IsNullOrWhiteSpace(path) ? "/socket.io" : path)
+                .Append("/?EIO=")
                 .Append(eio)
                 .Append("&transport=websocket");
 

--- a/SocketIOClient/UrlConverter.cs
+++ b/SocketIOClient/UrlConverter.cs
@@ -22,9 +22,8 @@ namespace SocketIOClient
             {
                 builder.Append(":").Append(httpUri.Port);
             }
-            builder.Append(httpUri.AbsolutePath);
             builder
-                .Append("/?EIO=")
+                .Append("/socket.io/?EIO=")
                 .Append(eio)
                 .Append("&transport=websocket");
 

--- a/server/app.js
+++ b/server/app.js
@@ -119,3 +119,32 @@ server.listen(3000);
 //https://stackoverflow.com/questions/19150220/creating-rooms-in-socket-io
 
 console.log('Socket IO server started');
+
+
+// path
+const serverWithPath = require('http').createServer();
+const ioWithPath = require('socket.io')(serverWithPath, {
+    path: "/test"
+});
+ioWithPath.on('connection', client => {
+
+    client.on('test', data => {
+        const type = typeof data;
+        if (type === "string") {
+            client.emit("test", data + " - server");
+        } else if (type === "object") {
+            data.source = "server";
+            client.emit("test", data);
+        } else if (type === "object") {
+            if (Array.isArray(data)) {
+                client.emit("test", data);
+            } else {
+                data.source = "server";
+                client.emit("test", data);
+            }
+        } else {
+            client.emit("test", "unknow type - server");
+        }
+    });
+});
+serverWithPath.listen(3001);


### PR DESCRIPTION
对于在子目录运行的socket.io server来说：
- `uri` - HTTP服务器地址：`https://example.com/subpath`
- `path` - socket.io服务路径（有默认值）：`/socket.io`
- `sionamespace` - socket.io命名空间：`sionamespace`

所有的请求都是发向`uri+path`的，但是`path`有个默认值，所以单拿出来了。

---

我在Node+Express+socket.io做服务端，不使用命名空间的情况下可以正常运行。其他情况还没测试，但是没动命名空间的代码，如果原本可用就应该可用。

记念第一次PR😀，如果有哪里弄得不好见谅