### PR TITLE
Add possibility to set EnabledSslProtocols for WebSocketSharpClient

### DIFF
--- a/src/SocketIOClient.NetFx/WebSocketClient/WebSocketSharpClient.cs
+++ b/src/SocketIOClient.NetFx/WebSocketClient/WebSocketSharpClient.cs
@@ -31,6 +31,8 @@ namespace SocketIOClient.NetFx.WebSocketClient
             _ws.OnMessage += OnMessage;
             _ws.OnError += OnError;
             _ws.OnClose += OnClose;
+            // set enabled client Ssl protocols as defined via options
+            _ws.SslConfiguration.EnabledSslProtocols = _io.Options.EnabledSslProtocols;
             _ws.Connect();
             if (_ws.ReadyState == WebSocketState.Closed || _ws.ReadyState == WebSocketState.Closing)
             {

--- a/src/SocketIOClient/SocketIOOptions.cs
+++ b/src/SocketIOClient/SocketIOOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
 
 namespace SocketIOClient
 {
@@ -20,6 +21,8 @@ namespace SocketIOClient
 
         public int ReconnectionDelay { get; set; } = 1000;
         public int ReconnectionDelayMax { get; set; } = 5000;
+
+        public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.Default;
 
         double _randomizationFactor;
         public double RandomizationFactor

--- a/src/SocketIOClient/SocketIOOptions.cs
+++ b/src/SocketIOClient/SocketIOOptions.cs
@@ -22,7 +22,7 @@ namespace SocketIOClient
         public int ReconnectionDelay { get; set; } = 1000;
         public int ReconnectionDelayMax { get; set; } = 5000;
 
-        public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.Default;
+        public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.None;
 
         double _randomizationFactor;
         public double RandomizationFactor


### PR DESCRIPTION
WebSocketSharpClient is using the SslProtocols.Default as configuration, which is (at least on my Windows 10) Sslv3+Tls1.0.

The change adds a new field to SocketIOOptions to set the desired enabled ssl protocols. If not set it will use the SslProtocols.Default.

This will allow running the NetFx client on systems where only Tlsv1.2 is allowed and the other protocols are disabled.