### PR TITLE
pingToken should be disposed.

### DIFF
--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -117,25 +117,24 @@ namespace SocketIOClient
         public async Task DisconnectAsync()
         {
             // throw if not connected
-            if (!Connected) throw new InvalidOperationException("SocketIO is not connected");
-
-            try
+            if (Connected)
             {
-                _pingToken.Cancel();
-                await Socket.SendMessageAsync("41" + Namespace);
-                await Socket.DisconnectAsync();
+                try
+                {
+                    _pingToken.Cancel();
+                    await Socket.SendMessageAsync("41" + Namespace);
+                    await Socket.DisconnectAsync();
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine(ex.Message);
+                }
+                finally
+                {
+                    Connected = false;
+                    Disconnected = true;
+                }
             }
-            catch (Exception ex)
-            {
-                Trace.WriteLine(ex.Message);
-                throw;
-            }
-            finally
-            {
-                Connected = false;
-                Disconnected = true;
-            }
-
         }
 
         public void On(string eventName, Action<SocketIOResponse> callback)

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -116,11 +116,26 @@ namespace SocketIOClient
 
         public async Task DisconnectAsync()
         {
-            await Socket.SendMessageAsync("41" + Namespace);
-            Connected = false;
-            Disconnected = true;
-            await Socket.DisconnectAsync();
-            _pingToken.Cancel();
+            // throw if not connected
+            if (!Connected) throw new InvalidOperationException("SocketIO is not connected");
+
+            try
+            {
+                _pingToken.Cancel();
+                await Socket.SendMessageAsync("41" + Namespace);
+                await Socket.DisconnectAsync();
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(ex.Message);
+                throw;
+            }
+            finally
+            {
+                Connected = false;
+                Disconnected = true;
+            }
+
         }
 
         public void On(string eventName, Action<SocketIOResponse> callback)
@@ -270,22 +285,27 @@ namespace SocketIOClient
         internal void Open(OpenResponse openResponse)
         {
             Id = openResponse.Sid;
+            _pingToken?.Cancel();
+            _pingToken?.Dispose();
             _pingToken = new CancellationTokenSource();
             Task.Factory.StartNew(async () =>
             {
-                await SendNamespaceAsync();
-                while (true)
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(_pingToken.Token))
                 {
-                    await Task.Delay(openResponse.PingInterval);
-                    if (_pingToken.IsCancellationRequested)
-                        return;
-                    try
+                    await SendNamespaceAsync();
+                    while (true)
                     {
-                        PingTime = DateTime.Now;
-                        await Socket.SendMessageAsync("2");
-                        OnPing?.Invoke(this, new EventArgs());
+                        await Task.Delay(openResponse.PingInterval);
+                        if (cts.Token.IsCancellationRequested)
+                            return;
+                        try
+                        {
+                            PingTime = DateTime.Now;
+                            await Socket.SendMessageAsync("2");
+                            OnPing?.Invoke(this, new EventArgs());
+                        }
+                        catch { }
                     }
-                    catch { }
                 }
             }, _pingToken.Token);
         }

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -116,24 +116,21 @@ namespace SocketIOClient
 
         public async Task DisconnectAsync()
         {
-            // throw if not connected
-            if (Connected)
+            if (Connected && !Disconnected)
             {
                 try
                 {
-                    _pingToken.Cancel();
                     await Socket.SendMessageAsync("41" + Namespace);
+                }
+                catch (Exception ex) { Trace.WriteLine(ex.Message); }
+                Connected = false;
+                Disconnected = true;
+                try
+                {
                     await Socket.DisconnectAsync();
                 }
-                catch (Exception ex)
-                {
-                    Trace.WriteLine(ex.Message);
-                }
-                finally
-                {
-                    Connected = false;
-                    Disconnected = true;
-                }
+                catch (Exception ex) { Trace.WriteLine(ex.Message); }
+                _pingToken.Cancel();
             }
         }
 

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -281,27 +281,22 @@ namespace SocketIOClient
         internal void Open(OpenResponse openResponse)
         {
             Id = openResponse.Sid;
-            _pingToken?.Cancel();
-            _pingToken?.Dispose();
             _pingToken = new CancellationTokenSource();
             Task.Factory.StartNew(async () =>
             {
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(_pingToken.Token))
+                await SendNamespaceAsync();
+                while (true)
                 {
-                    await SendNamespaceAsync();
-                    while (true)
+                    await Task.Delay(openResponse.PingInterval);
+                    if (_pingToken.IsCancellationRequested)
+                        return;
+                    try
                     {
-                        await Task.Delay(openResponse.PingInterval);
-                        if (cts.Token.IsCancellationRequested)
-                            return;
-                        try
-                        {
-                            PingTime = DateTime.Now;
-                            await Socket.SendMessageAsync("2");
-                            OnPing?.Invoke(this, new EventArgs());
-                        }
-                        catch { }
+                        PingTime = DateTime.Now;
+                        await Socket.SendMessageAsync("2");
+                        OnPing?.Invoke(this, new EventArgs());
                     }
+                    catch (Exception ex) { Trace.WriteLine(ex); }
                 }
             }, _pingToken.Token);
         }

--- a/src/SocketIOClient/WebSocketClient/ClientWebSocket.cs
+++ b/src/SocketIOClient/WebSocketClient/ClientWebSocket.cs
@@ -128,7 +128,7 @@ namespace SocketIOClient.WebSocketClient
         private async Task ListenAsync()
         {
             var buffer = new byte[ReceiveChunkSize];
-            while (_ws.State == WebSocketState.Open)
+            while (_ws.State == WebSocketState.Open && !_connectionToken.IsCancellationRequested)
             {
                 var stringResult = new StringBuilder();
                 var binaryResult = new List<byte>();

--- a/src/SocketIOClient/WebSocketClient/ClientWebSocket.cs
+++ b/src/SocketIOClient/WebSocketClient/ClientWebSocket.cs
@@ -49,8 +49,8 @@ namespace SocketIOClient.WebSocketClient
             //_ws.Options.ClientCertificates.Add(cert);
             _connectionToken = new CancellationTokenSource();
             await _ws.ConnectAsync(uri, _connectionToken.Token);
-            await Task.Factory.StartNew(ListenAsync, _connectionToken.Token);
-            await Task.Factory.StartNew(ListenStateAsync, _connectionToken.Token);
+            await Task.Factory.StartNew(ListenAsync);
+            await Task.Factory.StartNew(ListenStateAsync);
         }
 
         public virtual System.Net.WebSockets.ClientWebSocket CreateClient()
@@ -183,10 +183,12 @@ namespace SocketIOClient.WebSocketClient
             while (true)
             {
                 await Task.Delay(200);
+                if (_connectionToken.IsCancellationRequested)
+                    break;
                 if (_ws.State == WebSocketState.Closed || _ws.State == WebSocketState.Aborted)
                 {
                     Close("io server disconnect");
-                    return;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
1. pingToken should be disposed.
2. Socket.DisconnectAsync() may throw Exception, therefore _pingToken is never cancelled. I've seen multiple ping event tasks still running.