### PR TITLE
Fix the bug of Chinese string parsing garbled

### DIFF
--- a/src/SocketIOClient/WebSocketClient/ClientWebSocket.cs
+++ b/src/SocketIOClient/WebSocketClient/ClientWebSocket.cs
@@ -144,7 +144,7 @@ namespace SocketIOClient.WebSocketClient
             while (true)
             {
                 var buffer = new byte[ReceiveChunkSize];
-                var stringResult = new StringBuilder();
+                var stringResult = new List<byte>();
                 var binaryResult = new List<byte>();
                 WebSocketReceiveResult result = null;
                 while (_ws.State == WebSocketState.Open)
@@ -160,8 +160,7 @@ namespace SocketIOClient.WebSocketClient
                         }
                         else if (result.MessageType == WebSocketMessageType.Text)
                         {
-                            string str = Encoding.UTF8.GetString(buffer, 0, result.Count);
-                            stringResult.Append(str);
+                            stringResult.AddRange(buffer.Take(result.Count));
                         }
                         else if (result.MessageType == WebSocketMessageType.Binary)
                         {
@@ -184,7 +183,7 @@ namespace SocketIOClient.WebSocketClient
                 }
                 if (result.MessageType == WebSocketMessageType.Text)
                 {
-                    string message = stringResult.ToString();
+                    string message = Encoding.UTF8.GetString(stringResult.ToArray());
 #if DEBUG
                     Trace.WriteLine($"⬇ {DateTime.Now} {message}");
 #endif


### PR DESCRIPTION
bug test code

```csharp
        static void Main(string[] args)
        {
            var long_str =
                "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456我的电脑坏了我的电脑坏了";
            var data1 = Encoding.UTF8.GetBytes(long_str);
            var pack1 = new byte[1024];
            var pack2 = new byte[data1.Length - 1024];
            Buffer.BlockCopy(data1, 0, pack1, 0, pack1.Length);
            Buffer.BlockCopy(data1, 1024, pack2, 0, pack2.Length);
            string str = Encoding.UTF8.GetString(pack1);
            string str2 = Encoding.UTF8.GetString(pack2);
            var sb = new StringBuilder();
            sb.Append(str);
            sb.Append(str2);
            Console.WriteLine(long_str);
            Console.WriteLine(sb);
        }
```