### PR TITLE
fix: Catch websocket exception to detect disconnection & lock Emit to prevent race condition on OutgoingBytes

### DIFF
--- a/src/SocketIOClient/Processors/PingProcessor.cs
+++ b/src/SocketIOClient/Processors/PingProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace SocketIOClient.Processors
 {
@@ -8,10 +9,22 @@ namespace SocketIOClient.Processors
         {
             if (ctx.SocketIO.Options.EIO == 4)
             {
-                ctx.SocketIO.InvokePing();
-                DateTime pingTime = DateTime.Now;
-                await ctx.SocketIO.Socket.SendMessageAsync("3");
-                ctx.SocketIO.InvokePong(DateTime.Now - pingTime);
+                try
+                {
+                    ctx.SocketIO.InvokePing();
+                    DateTime pingTime = DateTime.Now;
+                    await ctx.SocketIO.Socket.SendMessageAsync("3");
+                    ctx.SocketIO.InvokePong(DateTime.Now - pingTime);
+                }
+                catch (System.Net.WebSockets.WebSocketException e)
+                {
+                    ctx.SocketIO.InvokeDisconnect(e.Message);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError(ex.ToString());
+                }
+                
             }
         }
     }


### PR DESCRIPTION
This fix #158, to reproduce poor connection I had to install NetBalencer tool which allow to simulate packet loss and connection loss. 
In such conditions we were not getting the disconnect event from the lib. Furthermore when connection was restored the lib started to send events again but they were malformated and it resulted in exception on the SIO server as well as in the lib, so I've implemented the fix you had implemented for #80 .