### PR TITLE
 feat: Add logic to run the different nodejs servers before the tests

### DIFF
--- a/src/SocketIOClient.Test/Helpers/CommandHelper.cs
+++ b/src/SocketIOClient.Test/Helpers/CommandHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace SocketIOClient.Test.Helpers
+{
+    public static class CommandHelper
+    {
+        public static Process RunCommand(string fileName, string argument, string workingDirectory = null)
+        {
+            if (string.IsNullOrEmpty(workingDirectory))
+            {
+                workingDirectory = Directory.GetDirectoryRoot(Directory.GetCurrentDirectory());
+            }
+
+            var processStartInfo = new ProcessStartInfo()
+            {
+                FileName = fileName,
+                Arguments = argument,
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = true,
+                WindowStyle = ProcessWindowStyle.Minimized,
+            };
+
+            var process = Process.Start(processStartInfo);
+
+            if (process == null)
+            {
+                throw new Exception("Process should not be null.");
+            }
+
+            return process;
+        }
+    }
+}

--- a/src/SocketIOClient.Test/SocketIOTests/AssemblyIntegrationTest.cs
+++ b/src/SocketIOClient.Test/SocketIOTests/AssemblyIntegrationTest.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SocketIOClient.Test.SocketIOTests.V4;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace SocketIOClient.Test.SocketIOTests
+{
+    [TestClass]
+
+    public class AssemblyIntegrationTest
+    {
+        private static readonly IEnumerable<IServerManager> Servers = new List<IServerManager>()
+        {
+            new ServerV2Manager(),
+            new ServerV3Manager(),
+            new ServerV4Manager()
+        };
+
+        [AssemblyInitialize]
+        public static void Initialize(TestContext context)
+        {
+            foreach (var server in Servers) 
+            {
+                server.Create();
+            }
+
+            // Give some time to be sure that servers are running.
+            Thread.Sleep(5000);
+        }
+
+        [AssemblyCleanup]
+        public static void Cleanup()
+        {
+            foreach (var server in Servers)
+            {
+                server.Destroy();
+            }
+        }
+    }
+}

--- a/src/SocketIOClient.Test/SocketIOTests/BaseServerManager.cs
+++ b/src/SocketIOClient.Test/SocketIOTests/BaseServerManager.cs
@@ -1,0 +1,50 @@
+﻿using SocketIOClient.Test.Helpers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace SocketIOClient.Test.SocketIOTests
+{
+    public class BaseServerManager
+    {
+        private readonly string directory;
+        private List<Process> processesToKill;
+
+        public BaseServerManager(string directory) 
+        {
+            this.directory = directory;
+        }
+
+        public void Create()
+        {
+            var installProcess = CommandHelper.RunCommand("npm", "install", Path.GetFullPath(directory));
+            
+            if (!installProcess.WaitForExit(60000)) 
+            {
+                throw new System.SystemException("Failed restoring packages of server");
+            }
+
+            var before = Process.GetProcesses().ToList().Select(x => x.Id);
+            var startProcess = CommandHelper.RunCommand("npm", "start", Path.GetFullPath(directory));
+            var after = Process.GetProcesses().ToList();
+            this.processesToKill = this.GetProcessesToKill(before, after);
+        }
+
+        public void Destroy()
+        {
+            foreach (var process in processesToKill)
+            {
+                process.Kill();
+            }
+        }
+
+        private List<Process> GetProcessesToKill(IEnumerable<int> before, List<Process> after)
+        {
+            var processesToKill = after;
+            processesToKill.RemoveAll(x => before.Contains(x.Id) && !x.ProcessName.Contains("npm"));
+            return processesToKill;
+        }
+    }
+}

--- a/src/SocketIOClient.Test/SocketIOTests/IServerManager.cs
+++ b/src/SocketIOClient.Test/SocketIOTests/IServerManager.cs
@@ -1,0 +1,8 @@
+﻿namespace SocketIOClient.Test.SocketIOTests
+{
+    public interface IServerManager
+    {
+        public void Create();
+        public void Destroy();
+    }
+}

--- a/src/SocketIOClient.Test/SocketIOTests/V2/ServerV2Manager.cs
+++ b/src/SocketIOClient.Test/SocketIOTests/V2/ServerV2Manager.cs
@@ -1,0 +1,10 @@
+﻿namespace SocketIOClient.Test.SocketIOTests.V4
+{
+    public class ServerV2Manager : BaseServerManager, IServerManager
+    {
+        public ServerV2Manager() 
+            : base(@"..\..\..\..\socket.io-server-v2")
+        {
+        }
+    }
+}

--- a/src/SocketIOClient.Test/SocketIOTests/V3/ServerV3Manager.cs
+++ b/src/SocketIOClient.Test/SocketIOTests/V3/ServerV3Manager.cs
@@ -1,0 +1,10 @@
+﻿namespace SocketIOClient.Test.SocketIOTests.V4
+{
+    public class ServerV3Manager : BaseServerManager, IServerManager
+    {
+        public ServerV3Manager() 
+            : base(@"..\..\..\..\socket.io-server-v3")
+        {
+        }
+    }
+}

--- a/src/SocketIOClient.Test/SocketIOTests/V4/ServerV4Manager.cs
+++ b/src/SocketIOClient.Test/SocketIOTests/V4/ServerV4Manager.cs
@@ -1,0 +1,10 @@
+﻿namespace SocketIOClient.Test.SocketIOTests.V4
+{
+    public class ServerV4Manager : BaseServerManager, IServerManager
+    {
+        public ServerV4Manager() 
+            : base(@"..\..\..\..\socket.io-server-v4")
+        {
+        }
+    }
+}


### PR DESCRIPTION
feat: Add logic to run the different nodejs servers before the tests to avoid making a lot of changes in the tests, the logic is performed by using AssemblyInitialize and the AssemblyCleanup instead of TestInitialize and TestCleanup (but could be done if desired). In the future, the tests could be separated in different projects (e.g. UnitTests and IntegrationTests), so, doing the configuration of the different servers should be done only by running the integration tests.