### PR TITLE
fixing reconnection when option is disabled

### DIFF
--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -210,6 +210,10 @@ namespace SocketIOClient
                 {
                     if (e is TimeoutException || e is WebSocketException)
                     {
+                        if (!Options.Reconnection)
+                        {
+                            throw;
+                        }
                         if (Attempts > 0)
                         {
                             OnReconnectError?.Invoke(this, e);


### PR DESCRIPTION
I was using this client with the following options
```
var client = new SocketIO(options.Value.Endpoint, new SocketIOOptions
{
      ConnectionTimeout = TimeSpan.FromSeconds(30),
      Reconnection = false
});
```
I was not getting any data or errors.
After debugging it, I've realized that this exception `WebSocketException` had been thrown, and this catch https://github.com/doghappy/socket.io-client-csharp/blob/master/src/SocketIOClient/SocketIO.cs#L209 was actually suppressing the exception, and even worst, it was reconnecting even I had defined the Reconnection flag as false. This PR fixes the issue, by throwing the exception when the Reconnect option is disabled.