### PR TITLE
Default ping interval

### DIFF
--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -184,6 +184,7 @@ namespace SocketIOClient
             Disconnected = true;
             JsonSerializer = new SystemTextJsonSerializer(Options.EIO);
             _connectionTokenSorce = new CancellationTokenSource();
+            _pingInterval = 5000;
         }
 
         public async Task ConnectAsync()


### PR DESCRIPTION
After OpenedProcessor.Process fails, OpenedHandler is not called and _pingInterval remains 0.
The socket is connected, but pings have 0ms intervals.
I suggest adding a default 5000ms interval as suggested by the Socket.IO documentation:
https://socket.io/docs/v3/server-api/index.html#:~:text=pingTimeout,the%20connection%20closed
