### PR TITLE
Using serializer for reading the input stream too, SocketIO becomes generic

### DIFF
--- a/src/SocketIOClient.Newtonsoft.Json/NewtonsoftJsonSerializer.cs
+++ b/src/SocketIOClient.Newtonsoft.Json/NewtonsoftJsonSerializer.cs
@@ -2,6 +2,8 @@
 using Newtonsoft.Json;
 using SocketIOClient.JsonSerializer;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using System.Linq;
 
 namespace SocketIOClient.Newtonsoft.Json
 {
@@ -61,6 +63,95 @@ namespace SocketIOClient.Newtonsoft.Json
             converter.Bytes.AddRange(bytes);
             var settings = NewSettings(converter);
             return JsonConvert.DeserializeObject(json, type, settings);
+        }
+
+        public List<T> GetListOfElementsFromRoot<T>(string json)
+        {
+            if (typeof(T) == typeof(JToken))
+            {
+                return (List<T>)(object)JsonConvert.DeserializeObject<JArray>(json, _settings).Root.AsJEnumerable().ToList();
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public string GetString<T>(T Json)
+        {
+            if (typeof(T) == typeof(JToken))
+            {
+                return ((JToken)(object)Json).ToString();
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public T GetRootElement<T>(string json)
+        {
+            if (typeof(T) == typeof(JToken))
+            {
+                return (T)(object)JsonConvert.DeserializeObject<JObject>(json,_settings).Root;
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public int GetInt32FromJsonElement<T>(T element, string message, string propertyName)
+        {
+            if (typeof(T) == typeof(JToken))
+            {
+                var p = ((JToken)(object)element).SelectToken(propertyName);
+                switch (p.Type)
+                {
+                    case JTokenType.Integer:
+                        return p.ToObject<int>();
+                    case JTokenType.Float:
+                        return int.Parse(p.ToString());
+                    case JTokenType.String:
+                        return int.Parse(p.ToString());
+                    default:
+                        throw new ArgumentException($"Invalid message: '{message}'");
+                }
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+
+        }
+
+        public T GetProperty<T>(T element, string propertyName)
+        {
+            if (typeof(T) == typeof(JToken))
+            {
+                var p = ((JToken)(object)element).SelectToken(propertyName);
+                return (T)(object)p;
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+
+        }
+
+        public List<T> GetListOfElements<T>(T element)
+        {
+            if (typeof(T) == typeof(JToken))
+            {
+                var e = ((JToken)(object)element);
+                return (List<T>)(object)e.AsJEnumerable().ToList();
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public string GetRawText<T>(T element)
+        {
+            if (typeof(T) == typeof(JToken))
+            {
+               return ((JToken)(object)element).ToString(Formatting.None);
+            }
+            else if(typeof(T) == typeof(JObject))
+            {
+                return ((JObject)(object)element).ToString(Formatting.None);
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
         }
     }
 }

--- a/src/SocketIOClient.Newtonsoft.Json/SocketIOClient.Newtonsoft.Json.csproj
+++ b/src/SocketIOClient.Newtonsoft.Json/SocketIOClient.Newtonsoft.Json.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.0.7</Version>
+    <Version>3.0.8</Version>
     <Description>socket.io-client json serialization/deserialization for Newtonsoft.Json</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/doghappy/socket.io-client-csharp</PackageProjectUrl>
@@ -10,6 +10,7 @@
     <RepositoryType>github</RepositoryType>
     <PackageTags>socket.io-client</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SocketIOClient/EventHandlers.cs
+++ b/src/SocketIOClient/EventHandlers.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 namespace SocketIOClient
 {
-    public delegate void OnAnyHandler(string eventName, SocketIOResponse response);
+    public delegate void OnAnyHandler<T>(string eventName, SocketIOResponse<T> response);
     public delegate void OnOpenedHandler(string sid, int pingInterval, int pingTimeout);
     //public delegate void OnDisconnectedHandler(string sid, int pingInterval, int pingTimeout);
     public delegate void OnAck(int packetId, List<JsonElement> array);

--- a/src/SocketIOClient/Extensions/SocketIOEventExtensions.cs
+++ b/src/SocketIOClient/Extensions/SocketIOEventExtensions.cs
@@ -4,7 +4,7 @@ namespace SocketIOClient.Extensions
 {
     internal static class SocketIOEventExtensions
     {
-        public static void TryInvoke(this OnAnyHandler handler, string eventName, SocketIOResponse response)
+        public static void TryInvoke<T>(this OnAnyHandler<T> handler, string eventName, SocketIOResponse<T> response)
         {
             try
             {
@@ -15,7 +15,7 @@ namespace SocketIOClient.Extensions
                 // The exception is thrown by the user code, so it can be swallowed
             }
         }
-        public static void TryInvoke(this Action<SocketIOResponse> handler, SocketIOResponse response)
+        public static void TryInvoke<T>(this Action<SocketIOResponse<T>> handler, SocketIOResponse<T> response)
         {
             try
             {

--- a/src/SocketIOClient/JsonSerializer/IJsonSerializer.cs
+++ b/src/SocketIOClient/JsonSerializer/IJsonSerializer.cs
@@ -10,5 +10,19 @@ namespace SocketIOClient.JsonSerializer
         object Deserialize(string json, Type type);
         T Deserialize<T>(string json, IList<byte[]> incomingBytes);
         object Deserialize(string json, Type type, IList<byte[]> incomingBytes);
+
+        List<T> GetListOfElementsFromRoot<T>(string json);
+
+        string GetString<T>(T Json);
+
+        T GetRootElement<T>(string json);
+        int GetInt32FromJsonElement<T>(T element, string message, string propertyName);
+
+        T GetProperty<T>(T element, string propertyName);
+
+        List<T> GetListOfElements<T>(T element);
+
+        string GetRawText<T>(T element);
+
     }
 }

--- a/src/SocketIOClient/JsonSerializer/SystemTextJsonSerializer.cs
+++ b/src/SocketIOClient/JsonSerializer/SystemTextJsonSerializer.cs
@@ -62,5 +62,90 @@ namespace SocketIOClient.JsonSerializer
             var options = NewOptions(converter);
             return System.Text.Json.JsonSerializer.Deserialize(json, type, options);
         }
+
+        public List<T> GetListOfElementsFromRoot<T>(string json)
+        {
+            if (typeof(T) == typeof(JsonElement))
+            {
+                return (List<T>)(object)((JsonDocument)System.Text.Json.JsonSerializer.Deserialize(json, typeof(JsonDocument), _options)).RootElement.EnumerateArray().ToList();
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public string GetString<T>(T Json)
+        {
+            if (typeof(T) == typeof(JsonElement))
+            {
+                return ((JsonElement)(object)Json).GetString();
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public T GetRootElement<T>(string json)
+        {
+            if (typeof(T) == typeof(JsonElement))
+            {
+                return (T)(object)((JsonDocument)System.Text.Json.JsonSerializer.Deserialize(json, typeof(JsonDocument), _options)).RootElement;
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+        public int GetInt32FromJsonElement<T>(T element, string message, string propertyName)
+        {
+            if (typeof(T) == typeof(JsonElement))
+            {
+                var p = ((JsonElement)(object)element).GetProperty(propertyName);
+                int val;
+                switch (p.ValueKind)
+                {
+                    case JsonValueKind.String:
+                        val = int.Parse(p.GetString());
+                        break;
+                    case JsonValueKind.Number:
+                        val = p.GetInt32();
+                        break;
+                    default:
+                        throw new ArgumentException($"Invalid message: '{message}'");
+                }
+                return val;
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public T GetProperty<T>(T element, string propertyName)
+        {
+            if (typeof(T) == typeof(JsonElement))
+            {
+                var p = ((JsonElement)(object)element).GetProperty(propertyName);
+                return ((T)(object)p);
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
+
+        public List<T> GetListOfElements<T>(T element)
+        {
+            if (typeof(T) == typeof(JsonElement))
+            {
+                var p = (JsonElement)(object)element;
+                return (List<T>)(object)p.EnumerateArray().ToList();
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+
+        }
+
+        public string GetRawText<T>(T element)
+        {
+            if (typeof(T) == typeof(JsonElement))
+            {
+                return ((JsonElement)(object)element).GetRawText();
+            }
+            else
+                throw new NotSupportedException($"Type {typeof(T)} is not supported in {GetType().Name}.");
+        }
     }
 }

--- a/src/SocketIOClient/Messages/ClientAckMessage.cs
+++ b/src/SocketIOClient/Messages/ClientAckMessage.cs
@@ -1,15 +1,15 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 
 namespace SocketIOClient.Messages
 {
     /// <summary>
     /// The server calls the client's callback
     /// </summary>
-    public class ClientAckMessage : IJsonMessage
+    public class ClientAckMessage<T> : IJsonMessage<T>
     {
         public MessageType Type => MessageType.AckMessage;
 
@@ -17,7 +17,6 @@ namespace SocketIOClient.Messages
 
         public string Event { get; set; }
 
-        public List<JsonElement> JsonElements { get; set; }
 
         public string Json { get; set; }
 
@@ -32,6 +31,9 @@ namespace SocketIOClient.Messages
         public EngineIO EIO { get; set; }
 
         public TransportProtocol Protocol { get; set; }
+        public IJsonSerializer Serializer { get; set; }
+
+        public List<T> JsonElements { get; set; }
 
         public void Read(string msg)
         {
@@ -48,7 +50,7 @@ namespace SocketIOClient.Messages
                 Id = int.Parse(msg.Substring(0, index));
             }
             msg = msg.Substring(index);
-            JsonElements = JsonDocument.Parse(msg).RootElement.EnumerateArray().ToList();
+            JsonElements = Serializer.GetListOfElementsFromRoot<T>(msg);
         }
 
         public string Write()

--- a/src/SocketIOClient/Messages/ClientBinaryAckMessage.cs
+++ b/src/SocketIOClient/Messages/ClientBinaryAckMessage.cs
@@ -1,15 +1,15 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 
 namespace SocketIOClient.Messages
 {
     /// <summary>
     /// The server calls the client's callback with binary
     /// </summary>
-    public class ClientBinaryAckMessage : IJsonMessage
+    public class ClientBinaryAckMessage<T> : IJsonMessage<T>
     {
         public MessageType Type => MessageType.BinaryAckMessage;
 
@@ -17,7 +17,7 @@ namespace SocketIOClient.Messages
 
         public string Event { get; set; }
 
-        public List<JsonElement> JsonElements { get; set; }
+        public List<T> JsonElements { get; set; }
 
         public string Json { get; set; }
 
@@ -32,6 +32,7 @@ namespace SocketIOClient.Messages
         public List<byte[]> OutgoingBytes { get; set; }
 
         public List<byte[]> IncomingBytes { get; set; }
+        public IJsonSerializer Serializer { get ; set ; }
 
         public void Read(string msg)
         {
@@ -52,7 +53,7 @@ namespace SocketIOClient.Messages
             }
 
             string json = msg.Substring(index2);
-            JsonElements = JsonDocument.Parse(json).RootElement.EnumerateArray().ToList();
+            JsonElements = Serializer.GetListOfElementsFromRoot<T>(json);
         }
 
         public string Write()

--- a/src/SocketIOClient/Messages/ConnectedMessage.cs
+++ b/src/SocketIOClient/Messages/ConnectedMessage.cs
@@ -2,11 +2,11 @@
 using SocketIOClient.Transport;
 using System.Collections.Generic;
 using System.Text;
-using System.Text.Json;
+using SocketIOClient.JsonSerializer;
 
 namespace SocketIOClient.Messages
 {
-    public class ConnectedMessage : IMessage
+    public class ConnectedMessage<T> : IMessage
     {
         public MessageType Type => MessageType.Connected;
 
@@ -26,6 +26,7 @@ namespace SocketIOClient.Messages
 
         public IEnumerable<KeyValuePair<string, string>> Query { get; set; }
         public string AuthJsonStr { get; set; }
+        public IJsonSerializer Serializer { get; set; }
 
         public void Read(string msg)
         {
@@ -60,7 +61,8 @@ namespace SocketIOClient.Messages
             {
                 Namespace = string.Empty;
             }
-            Sid = JsonDocument.Parse(msg).RootElement.GetProperty("sid").GetString();
+            //Sid = JsonDocument.Parse(msg).RootElement.GetProperty("sid").GetString();
+            Sid = Serializer.GetString<T>(Serializer.GetProperty<T>(Serializer.GetRootElement<T>(msg), "sid"));
         }
 
         private string Eio4Write()

--- a/src/SocketIOClient/Messages/DisconnectedMessage.cs
+++ b/src/SocketIOClient/Messages/DisconnectedMessage.cs
@@ -1,9 +1,10 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System.Collections.Generic;
 
 namespace SocketIOClient.Messages
 {
-    public class DisconnectedMessage : IMessage
+    public class DisconnectedMessage<T> : IMessage
     {
         public MessageType Type => MessageType.Disconnected;
 
@@ -18,6 +19,7 @@ namespace SocketIOClient.Messages
         public EngineIO EIO { get; set; }
 
         public TransportProtocol Protocol { get; set; }
+        public IJsonSerializer Serializer { get; set; }
 
         public void Read(string msg)
         {

--- a/src/SocketIOClient/Messages/ErrorMessage.cs
+++ b/src/SocketIOClient/Messages/ErrorMessage.cs
@@ -1,11 +1,12 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
+
 
 namespace SocketIOClient.Messages
 {
-    public class ErrorMessage : IMessage
+    public class ErrorMessage<T> : IMessage
     {
         public MessageType Type => MessageType.ErrorMessage;
 
@@ -22,6 +23,7 @@ namespace SocketIOClient.Messages
         public EngineIO EIO { get; set; }
 
         public TransportProtocol Protocol { get; set; }
+        public IJsonSerializer Serializer { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public void Read(string msg)
         {
@@ -37,8 +39,10 @@ namespace SocketIOClient.Messages
                     Namespace = msg.Substring(0, index - 1);
                     msg = msg.Substring(index);
                 }
-                var doc = JsonDocument.Parse(msg);
-                Message = doc.RootElement.GetProperty("message").GetString();
+                //var doc = JsonDocument.Parse(msg);
+                var doc = Serializer.GetRootElement<T>(msg);
+                //Message = doc.RootElement.GetProperty("message").GetString();
+                Message = Serializer.GetString<T>(Serializer.GetProperty<T>(doc, "message"));
             }
         }
 

--- a/src/SocketIOClient/Messages/ErrorMessage.cs
+++ b/src/SocketIOClient/Messages/ErrorMessage.cs
@@ -23,7 +23,7 @@ namespace SocketIOClient.Messages
         public EngineIO EIO { get; set; }
 
         public TransportProtocol Protocol { get; set; }
-        public IJsonSerializer Serializer { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IJsonSerializer Serializer { get; set; }
 
         public void Read(string msg)
         {

--- a/src/SocketIOClient/Messages/IJsonMessage.cs
+++ b/src/SocketIOClient/Messages/IJsonMessage.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
-using System.Text.Json;
 
 namespace SocketIOClient.Messages
 {
-    public interface IJsonMessage : IMessage
+    public interface IJsonMessage<T> : IMessage
     {
-        List<JsonElement> JsonElements { get; }
+        List<T> JsonElements { get; }
     }
 }

--- a/src/SocketIOClient/Messages/IMessage.cs
+++ b/src/SocketIOClient/Messages/IMessage.cs
@@ -1,4 +1,5 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System.Collections.Generic;
 
 namespace SocketIOClient.Messages
@@ -18,6 +19,8 @@ namespace SocketIOClient.Messages
         TransportProtocol Protocol { get; set; }
 
         void Read(string msg);
+
+        IJsonSerializer Serializer{ get; set; }
 
         //void Eio3WsRead(string msg);
 

--- a/src/SocketIOClient/Messages/MessageFactory.cs
+++ b/src/SocketIOClient/Messages/MessageFactory.cs
@@ -56,17 +56,19 @@ namespace SocketIOClient.Messages
             return null;
         }
 
-        public static OpenedMessage<T> CreateOpenedMessage(string msg)
+        public static OpenedMessage<T> CreateOpenedMessage(string msg, IJsonSerializer serializer)
         {
             var openedMessage = new OpenedMessage<T>();
             if (msg[0] == '0')
             {
                 openedMessage.EIO = EngineIO.V4;
+                openedMessage.Serializer = serializer;
                 openedMessage.Read(msg.Substring(1));
             }
             else
             {
                 openedMessage.EIO = EngineIO.V3;
+                openedMessage.Serializer = serializer;
                 int index = msg.IndexOf(':');
                 openedMessage.Read(msg.Substring(index + 2));
             }

--- a/src/SocketIOClient/Messages/MessageFactory.cs
+++ b/src/SocketIOClient/Messages/MessageFactory.cs
@@ -1,40 +1,41 @@
-﻿using System;
+﻿using SocketIOClient.JsonSerializer;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace SocketIOClient.Messages
 {
-    public static class MessageFactory
+    public static class MessageFactory<T>
     {
         private static IMessage CreateMessage(MessageType type)
         {
             switch (type)
             {
                 case MessageType.Opened:
-                    return new OpenedMessage();
+                    return new OpenedMessage<T>();
                 case MessageType.Ping:
-                    return new PingMessage();
+                    return new PingMessage<T>();
                 case MessageType.Pong:
-                    return new PongMessage();
+                    return new PongMessage<T>();
                 case MessageType.Connected:
-                    return new ConnectedMessage();
+                    return new ConnectedMessage<T>();
                 case MessageType.Disconnected:
-                    return new DisconnectedMessage();
+                    return new DisconnectedMessage<T>();
                 case MessageType.EventMessage:
-                    return new EventMessage();
+                    return new EventMessage<T>();
                 case MessageType.AckMessage:
-                    return new ClientAckMessage();
+                    return new ClientAckMessage<T>();
                 case MessageType.ErrorMessage:
-                    return new ErrorMessage();
+                    return new ErrorMessage<T>();
                 case MessageType.BinaryMessage:
-                    return new BinaryMessage();
+                    return new BinaryMessage<T>();
                 case MessageType.BinaryAckMessage:
-                    return new ClientBinaryAckMessage();
+                    return new ClientBinaryAckMessage<T>();
             }
             return null;
         }
 
-        public static IMessage CreateMessage(EngineIO eio, string msg)
+        public static IMessage CreateMessage(EngineIO eio,IJsonSerializer serializer, string msg)
         {
             var enums = Enum.GetValues(typeof(MessageType));
             foreach (MessageType item in enums)
@@ -45,6 +46,7 @@ namespace SocketIOClient.Messages
                     IMessage result = CreateMessage(item);
                     if (result != null)
                     {
+                        result.Serializer = serializer;
                         result.EIO = eio;
                         result.Read(msg.Substring(prefix.Length));
                         return result;
@@ -54,9 +56,9 @@ namespace SocketIOClient.Messages
             return null;
         }
 
-        public static OpenedMessage CreateOpenedMessage(string msg)
+        public static OpenedMessage<T> CreateOpenedMessage(string msg)
         {
-            var openedMessage = new OpenedMessage();
+            var openedMessage = new OpenedMessage<T>();
             if (msg[0] == '0')
             {
                 openedMessage.EIO = EngineIO.V4;

--- a/src/SocketIOClient/Messages/PingMessage.cs
+++ b/src/SocketIOClient/Messages/PingMessage.cs
@@ -1,9 +1,10 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System.Collections.Generic;
 
 namespace SocketIOClient.Messages
 {
-    public class PingMessage : IMessage
+    public class PingMessage<T> : IMessage
     {
         public MessageType Type => MessageType.Ping;
 
@@ -16,6 +17,7 @@ namespace SocketIOClient.Messages
         public EngineIO EIO { get; set; }
 
         public TransportProtocol Protocol { get; set; }
+        public IJsonSerializer Serializer { get ; set ; }
 
         public void Read(string msg)
         {

--- a/src/SocketIOClient/Messages/PongMessage.cs
+++ b/src/SocketIOClient/Messages/PongMessage.cs
@@ -1,10 +1,11 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System;
 using System.Collections.Generic;
 
 namespace SocketIOClient.Messages
 {
-    public class PongMessage : IMessage
+    public class PongMessage<T> : IMessage
     {
         public MessageType Type => MessageType.Pong;
 
@@ -19,6 +20,7 @@ namespace SocketIOClient.Messages
         public TransportProtocol Protocol { get; set; }
 
         public TimeSpan Duration { get; set; }
+        public IJsonSerializer Serializer { get; set; }
 
         public void Read(string msg)
         {

--- a/src/SocketIOClient/Messages/ServerAckMessage.cs
+++ b/src/SocketIOClient/Messages/ServerAckMessage.cs
@@ -1,4 +1,5 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +8,7 @@ namespace SocketIOClient.Messages
     /// <summary>
     /// The client calls the server's callback
     /// </summary>
-    public class ServerAckMessage : IMessage
+    public class ServerAckMessage<T> : IMessage
     {
         public MessageType Type => MessageType.AckMessage;
 
@@ -26,6 +27,7 @@ namespace SocketIOClient.Messages
         public EngineIO EIO { get; set; }
 
         public TransportProtocol Protocol { get; set; }
+        public IJsonSerializer Serializer { get; set; }
 
         public void Read(string msg)
         {

--- a/src/SocketIOClient/Messages/ServerBinaryAckMessage.cs
+++ b/src/SocketIOClient/Messages/ServerBinaryAckMessage.cs
@@ -1,20 +1,20 @@
-﻿using SocketIOClient.Transport;
+﻿using SocketIOClient.JsonSerializer;
+using SocketIOClient.Transport;
 using System.Collections.Generic;
 using System.Text;
-using System.Text.Json;
 
 namespace SocketIOClient.Messages
 {
     /// <summary>
     /// The client calls the server's callback with binary
     /// </summary>
-    public class ServerBinaryAckMessage : IJsonMessage
+    public class ServerBinaryAckMessage<T> : IJsonMessage<T>
     {
         public MessageType Type => MessageType.BinaryAckMessage;
 
         public string Namespace { get; set; }
 
-        public List<JsonElement> JsonElements { get; set; }
+        public List<T> JsonElements { get; set; }
 
         public string Json { get; set; }
 
@@ -29,6 +29,7 @@ namespace SocketIOClient.Messages
         public List<byte[]> OutgoingBytes { get; set; }
 
         public List<byte[]> IncomingBytes { get; set; }
+        public IJsonSerializer Serializer { get ; set ; }
 
         public void Read(string msg)
         {

--- a/src/SocketIOClient/SocketIOClient.csproj
+++ b/src/SocketIOClient/SocketIOClient.csproj
@@ -12,11 +12,12 @@
 		<PackageTags>socket.io-client</PackageTags>
 		<RepositoryType>github</RepositoryType>
 		<PackageLicenseFile></PackageLicenseFile>
-		<Version>3.0.8</Version>
+		<Version>3.0.9</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>SocketIOClient.snk</AssemblyOriginatorKeyFile>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/SocketIOClient/SocketIOResponse.cs
+++ b/src/SocketIOClient/SocketIOResponse.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace SocketIOClient
 {
-    public class SocketIOResponse
+    public class SocketIOResponse<T>
     {
-        public SocketIOResponse(IList<JsonElement> array, SocketIO socket)
+        public SocketIOResponse(IList<T> array, SocketIO<T> socket)
         {
             _array = array;
             InComingBytes = new List<byte[]>();
@@ -16,20 +16,20 @@ namespace SocketIOClient
             PacketId = -1;
         }
 
-        readonly IList<JsonElement> _array;
+        readonly IList<T> _array;
 
         public List<byte[]> InComingBytes { get; }
-        public SocketIO SocketIO { get; }
+        public SocketIO<T> SocketIO { get; }
         public int PacketId { get; set; }
 
-        public T GetValue<T>(int index = 0)
-        {
-            var element = GetValue(index);
-            string json = element.GetRawText();
-            return SocketIO.JsonSerializer.Deserialize<T>(json, InComingBytes);
-        }
+        //public T GetValue<T>(int index = 0)
+        //{
+        //    var element = GetValue(index);
+        //    string json = element.GetRawText();
+        //    return SocketIO.JsonSerializer.Deserialize<T>(json, InComingBytes);
+        //}
 
-        public JsonElement GetValue(int index = 0) => _array[index];
+        public T GetValue(int index = 0) => _array[index];
 
         public int Count => _array.Count;
 
@@ -39,7 +39,7 @@ namespace SocketIOClient
             builder.Append('[');
             foreach (var item in _array)
             {
-                builder.Append(item.GetRawText());
+                builder.Append(SocketIO.JsonSerializer.GetRawText(item));
                 if (_array.IndexOf(item) < _array.Count - 1)
                 {
                     builder.Append(',');

--- a/src/SocketIOClient/SocketIOResponse.cs
+++ b/src/SocketIOClient/SocketIOResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using SocketIOClient.JsonSerializer;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -37,12 +38,25 @@ namespace SocketIOClient
         {
             var builder = new StringBuilder();
             builder.Append('[');
-            foreach (var item in _array)
-            {
-                builder.Append(SocketIO.JsonSerializer.GetRawText(item));
-                if (_array.IndexOf(item) < _array.Count - 1)
+            if (SocketIO != null)
+                foreach (var item in _array)
                 {
-                    builder.Append(',');
+                    builder.Append(SocketIO.JsonSerializer.GetRawText(item));
+                    if (_array.IndexOf(item) < _array.Count - 1)
+                    {
+                        builder.Append(',');
+                    }
+                }
+            else
+            {
+                var defaultSerializer = new SystemTextJsonSerializer();
+                foreach (var item in _array)
+                {
+                    builder.Append(defaultSerializer.GetRawText(item));
+                    if (_array.IndexOf(item) < _array.Count - 1)
+                    {
+                        builder.Append(',');
+                    }
                 }
             }
             builder.Append(']');

--- a/src/SocketIOClient/Transport/Http/HttpTransport.cs
+++ b/src/SocketIOClient/Transport/Http/HttpTransport.cs
@@ -5,13 +5,14 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using SocketIOClient.Extensions;
+using SocketIOClient.JsonSerializer;
 using SocketIOClient.Messages;
 
 namespace SocketIOClient.Transport.Http
 {
-    public class HttpTransport : BaseTransport
+    public class HttpTransport<T> : BaseTransport<T>
     {
-        public HttpTransport(TransportOptions options, IHttpPollingHandler pollingHandler) : base(options)
+        public HttpTransport(TransportOptions options, IHttpPollingHandler pollingHandler,IJsonSerializer Serializer) : base(options,Serializer)
         {
             _pollingHandler = pollingHandler ?? throw new ArgumentNullException(nameof(pollingHandler));
             _pollingHandler.OnTextReceived = OnTextReceived;
@@ -134,7 +135,7 @@ namespace SocketIOClient.Transport.Http
             }
         }
 
-        protected override async Task OpenAsync(OpenedMessage msg)
+        protected override async Task OpenAsync(OpenedMessage<T> msg)
         {
             _httpUri += "&sid=" + msg.Sid;
             _pollingTokenSource = new CancellationTokenSource();

--- a/src/SocketIOClient/Transport/WebSockets/DefaultClientWebSocket.cs
+++ b/src/SocketIOClient/Transport/WebSockets/DefaultClientWebSocket.cs
@@ -26,7 +26,7 @@ namespace SocketIOClient.Transport.WebSockets
         {
             "User-Agent"
         };
-
+       
         private void AllowHeaders()
         {
             var property = _ws.Options
@@ -62,13 +62,14 @@ namespace SocketIOClient.Transport.WebSockets
             }
         }
 #endif
-
+        public Action<object> ConfigOptions { get; set; }
         readonly ClientWebSocket _ws;
 
         public WebSocketState State => (WebSocketState)_ws.State;
 
         public async Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
         {
+            ConfigOptions?.Invoke(_ws.Options);
             await _ws.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/SocketIOClient/Transport/WebSockets/WebSocketTransport.cs
+++ b/src/SocketIOClient/Transport/WebSockets/WebSocketTransport.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using SocketIOClient.Extensions;
+using SocketIOClient.JsonSerializer;
 
 #if DEBUG
 using System.Diagnostics;
@@ -11,9 +12,9 @@ using System.Diagnostics;
 
 namespace SocketIOClient.Transport.WebSockets
 {
-    public class WebSocketTransport : BaseTransport
+    public class WebSocketTransport<T> : BaseTransport<T>
     {
-        public WebSocketTransport(TransportOptions options, IClientWebSocket ws) : base(options)
+        public WebSocketTransport(TransportOptions options, IClientWebSocket ws, IJsonSerializer serializer) : base(options,serializer)
         {
             _ws = ws;
             _sendLock = new SemaphoreSlim(1, 1);

--- a/tests/SocketIOClient.IntegrationTests.Net472/V4WebSocketTests.cs
+++ b/tests/SocketIOClient.IntegrationTests.Net472/V4WebSocketTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SocketIOClient.Transport;
+using System.Text.Json;
 
 namespace SocketIOClient.IntegrationTests.Net472
 {
@@ -16,7 +17,7 @@ namespace SocketIOClient.IntegrationTests.Net472
         public async Task ExtraHeaders(string key, string value)
         {
             string actual = null;
-            using (var io = new SocketIO(Common.Startup.V4_WS, new SocketIOOptions
+            using (var io = new SocketIO<JsonElement>(Common.Startup.V4_WS, new SocketIOOptions
             {
                 Reconnection = false,
                 EIO = EngineIO.V4,
@@ -29,7 +30,8 @@ namespace SocketIOClient.IntegrationTests.Net472
             {
                 await io.ConnectAsync();
                 await io.EmitAsync("get_header",
-                    res => actual = res.GetValue<string>(),
+                    //res => actual = res.GetValue<string>(),
+                    res => actual = io.JsonSerializer.GetString(res.GetValue()),
                     key.ToLower());
                 await Task.Delay(100);
 

--- a/tests/SocketIOClient.IntegrationTests/V4WebSocketTests.cs
+++ b/tests/SocketIOClient.IntegrationTests/V4WebSocketTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System;
 using System.Net.Sockets;
+using SocketIOClient.JsonSerializer;
 
 namespace SocketIOClient.IntegrationTests
 {
@@ -20,7 +21,8 @@ namespace SocketIOClient.IntegrationTests
         {
             using var io = CreateSocketIO();
             var results = new List<int>();
-            io.On("1:emit", res => results.Add(6 / res.GetValue<int>()));
+            var serializer = new SystemTextJsonSerializer();
+            io.On("1:emit", res => results.Add(6 / serializer.Deserialize<int>(res.GetValue().ToString())));
 
             await io.ConnectAsync();
             await io.EmitAsync("1:emit", 0);

--- a/tests/SocketIOClient.UnitTests/MessageTests/MessageFactoryTest.cs
+++ b/tests/SocketIOClient.UnitTests/MessageTests/MessageFactoryTest.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SocketIOClient.JsonSerializer;
 using SocketIOClient.Messages;
+using System.Text.Json;
 
 namespace SocketIOClient.UnitTests.MessageTests
 {
@@ -9,7 +11,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void CreateEio3HttpOpenedMessage()
         {
-            var msg = MessageFactory.CreateOpenedMessage("97:0{\"sid\":\"wOuAvDB9Jj6yE0VrAL8N\",\"upgrades\":[\"websocket\"],\"pingInterval\":25000,\"pingTimeout\":30000}");
+            var msg = MessageFactory<JsonElement>.CreateOpenedMessage("97:0{\"sid\":\"wOuAvDB9Jj6yE0VrAL8N\",\"upgrades\":[\"websocket\"],\"pingInterval\":25000,\"pingTimeout\":30000}", new SystemTextJsonSerializer());
             Assert.AreEqual(MessageType.Opened, msg.Type);
             Assert.AreEqual("wOuAvDB9Jj6yE0VrAL8N", msg.Sid);
             Assert.AreEqual(25000, msg.PingInterval);
@@ -22,7 +24,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void CreateEio3HttpOpenedMessageWithQuote()
         {
-            var msg = MessageFactory.CreateOpenedMessage("97:0{\"sid\":\"wOuAvDB9Jj6yE0VrAL8N\",\"upgrades\":[\"websocket\"],\"pingInterval\":\"26000\",\"pingTimeout\":\"31000\"}");
+            var msg = MessageFactory<JsonElement>.CreateOpenedMessage("97:0{\"sid\":\"wOuAvDB9Jj6yE0VrAL8N\",\"upgrades\":[\"websocket\"],\"pingInterval\":\"26000\",\"pingTimeout\":\"31000\"}", new SystemTextJsonSerializer());
             Assert.AreEqual(MessageType.Opened, msg.Type);
             Assert.AreEqual("wOuAvDB9Jj6yE0VrAL8N", msg.Sid);
             Assert.AreEqual(26000, msg.PingInterval);
@@ -35,7 +37,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void CreateEio4OpenedMessage()
         {
-            var msg = MessageFactory.CreateOpenedMessage("0{\"sid\":\"6lV4Ef7YOyGF-5dCBvKy\",\"upgrades\":[],\"pingInterval\":10000,\"pingTimeout\":5000}");
+            var msg = MessageFactory<JsonElement>.CreateOpenedMessage("0{\"sid\":\"6lV4Ef7YOyGF-5dCBvKy\",\"upgrades\":[],\"pingInterval\":10000,\"pingTimeout\":5000}", new SystemTextJsonSerializer());
             Assert.AreEqual(MessageType.Opened, msg.Type);
             Assert.AreEqual("6lV4Ef7YOyGF-5dCBvKy", msg.Sid);
             Assert.AreEqual(10000, msg.PingInterval);
@@ -47,7 +49,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void CreateEio4OpenedMessageWithQuote()
         {
-            var msg = MessageFactory.CreateOpenedMessage("0{\"sid\":\"6lV4Ef7YOyGF-5dCBvKy\",\"upgrades\":[],\"pingInterval\":\"20000\",\"pingTimeout\":\"6000\"}");
+            var msg = MessageFactory<JsonElement>.CreateOpenedMessage("0{\"sid\":\"6lV4Ef7YOyGF-5dCBvKy\",\"upgrades\":[],\"pingInterval\":\"20000\",\"pingTimeout\":\"6000\"}", new SystemTextJsonSerializer());
             Assert.AreEqual(MessageType.Opened, msg.Type);
             Assert.AreEqual("6lV4Ef7YOyGF-5dCBvKy", msg.Sid);
             Assert.AreEqual(20000, msg.PingInterval);

--- a/tests/SocketIOClient.UnitTests/MessageTests/MessageReadTest.cs
+++ b/tests/SocketIOClient.UnitTests/MessageTests/MessageReadTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SocketIOClient.JsonSerializer;
 using SocketIOClient.Messages;
 
 namespace SocketIOClient.UnitTests.MessageTests
@@ -10,24 +11,24 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Ping()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "2");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4,new SystemTextJsonSerializer(), "2");
             Assert.AreEqual(MessageType.Ping, msg.Type);
         }
 
         [TestMethod]
         public void Pong()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "3");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "3");
             Assert.AreEqual(MessageType.Pong, msg.Type);
         }
 
         [TestMethod]
         public void Eio4Connected()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "40{\"sid\":\"aMA_EmVTuzpgR16PAc4w\"}");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "40{\"sid\":\"aMA_EmVTuzpgR16PAc4w\"}");
             Assert.AreEqual(MessageType.Connected, msg.Type);
 
-            var connectedMsg = msg as ConnectedMessage;
+            var connectedMsg = msg as ConnectedMessage<JsonElement>;
 
             Assert.AreEqual(string.Empty, connectedMsg.Namespace);
             Assert.AreEqual("aMA_EmVTuzpgR16PAc4w", connectedMsg.Sid);
@@ -36,10 +37,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio4NamespaceConnected()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "40/nsp,{\"sid\":\"xO_jp2_xrGtXUveLAc4y\"}");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "40/nsp,{\"sid\":\"xO_jp2_xrGtXUveLAc4y\"}");
             Assert.AreEqual(MessageType.Connected, msg.Type);
 
-            var connectedMsg = msg as ConnectedMessage;
+            var connectedMsg = msg as ConnectedMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", connectedMsg.Namespace);
             Assert.AreEqual("xO_jp2_xrGtXUveLAc4y", connectedMsg.Sid);
@@ -48,10 +49,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3Connected()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V3, "40");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V3, new SystemTextJsonSerializer(), "40");
             Assert.AreEqual(MessageType.Connected, msg.Type);
 
-            var connectedMsg = msg as ConnectedMessage;
+            var connectedMsg = msg as ConnectedMessage<JsonElement>;
 
             Assert.IsTrue(string.IsNullOrEmpty(connectedMsg.Namespace));
             Assert.IsNull(connectedMsg.Sid);
@@ -60,10 +61,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3NamespaceConnected1()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V3, "40/nsp,");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V3, new SystemTextJsonSerializer(),"40/nsp,");
             Assert.AreEqual(MessageType.Connected, msg.Type);
 
-            var connectedMsg = msg as ConnectedMessage;
+            var connectedMsg = msg as ConnectedMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", connectedMsg.Namespace);
             Assert.IsNull(connectedMsg.Sid);
@@ -72,10 +73,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3NamespaceConnected2()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V3, "40/nsp");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V3, new SystemTextJsonSerializer(), "40/nsp");
             Assert.AreEqual(MessageType.Connected, msg.Type);
 
-            var connectedMsg = msg as ConnectedMessage;
+            var connectedMsg = msg as ConnectedMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", connectedMsg.Namespace);
             Assert.IsNull(connectedMsg.Sid);
@@ -84,10 +85,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3NamespaceConnected3()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V3, "40/nsp?token=V2,");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V3, new SystemTextJsonSerializer(), "40/nsp?token=V2,");
             Assert.AreEqual(MessageType.Connected, msg.Type);
 
-            var connectedMsg = msg as ConnectedMessage;
+            var connectedMsg = msg as ConnectedMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", connectedMsg.Namespace);
             Assert.IsNull(connectedMsg.Sid);
@@ -96,10 +97,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3NamespaceConnected4()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V3, "40/nsp?token=V2");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V3, new SystemTextJsonSerializer(), "40/nsp?token=V2");
             Assert.AreEqual(MessageType.Connected, msg.Type);
 
-            var connectedMsg = msg as ConnectedMessage;
+            var connectedMsg = msg as ConnectedMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", connectedMsg.Namespace);
             Assert.IsNull(connectedMsg.Sid);
@@ -108,10 +109,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Disconnected()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "41");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "41");
             Assert.AreEqual(MessageType.Disconnected, msg.Type);
 
-            var realMsg = msg as DisconnectedMessage;
+            var realMsg = msg as DisconnectedMessage<JsonElement>;
 
             Assert.AreEqual(string.Empty, realMsg.Namespace);
         }
@@ -119,10 +120,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceDisconnected()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "41/github,");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "41/github,");
             Assert.AreEqual(MessageType.Disconnected, msg.Type);
 
-            var realMsg = msg as DisconnectedMessage;
+            var realMsg = msg as DisconnectedMessage<JsonElement>;
 
             Assert.AreEqual("/github", realMsg.Namespace);
         }
@@ -130,10 +131,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Event0Param()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "42[\"hi\"]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "42[\"hi\"]");
             Assert.AreEqual(MessageType.EventMessage, msg.Type);
 
-            var realMsg = msg as EventMessage;
+            var realMsg = msg as EventMessage<JsonElement>;
 
             Assert.IsTrue(string.IsNullOrEmpty(realMsg.Namespace));
 
@@ -144,10 +145,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Event1Param()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "42[\"hi\",\"V3: onAny\"]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "42[\"hi\",\"V3: onAny\"]");
             Assert.AreEqual(MessageType.EventMessage, msg.Type);
 
-            var realMsg = msg as EventMessage;
+            var realMsg = msg as EventMessage<JsonElement>;
 
             Assert.IsTrue(string.IsNullOrEmpty(realMsg.Namespace));
 
@@ -159,10 +160,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceEvent0Param()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "42/nsp,[\"234\"]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "42/nsp,[\"234\"]");
             Assert.AreEqual(MessageType.EventMessage, msg.Type);
 
-            var realMsg = msg as EventMessage;
+            var realMsg = msg as EventMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", realMsg.Namespace);
 
@@ -173,10 +174,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceEvent1Param()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "42/nsp,[\"qww\",true]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "42/nsp,[\"qww\",true]");
             Assert.AreEqual(MessageType.EventMessage, msg.Type);
 
-            var realMsg = msg as EventMessage;
+            var realMsg = msg as EventMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", realMsg.Namespace);
 
@@ -188,10 +189,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void EventMessageWithId()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "42/nsp,17[\"client calls the server's callback 0\"]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "42/nsp,17[\"client calls the server's callback 0\"]");
             Assert.AreEqual(MessageType.EventMessage, msg.Type);
 
-            var realMsg = msg as EventMessage;
+            var realMsg = msg as EventMessage<JsonElement>;
 
             Assert.AreEqual("/nsp", realMsg.Namespace);
 
@@ -203,10 +204,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Ack()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "431[\"doghappy\"]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "431[\"doghappy\"]");
             Assert.AreEqual(MessageType.AckMessage, msg.Type);
 
-            var realMsg = msg as ClientAckMessage;
+            var realMsg = msg as ClientAckMessage<JsonElement>;
 
             Assert.IsTrue(string.IsNullOrEmpty(realMsg.Namespace));
             Assert.AreEqual(1, realMsg.Id);
@@ -218,10 +219,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceAck()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "43/google,15[\"doghappy\"]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "43/google,15[\"doghappy\"]");
             Assert.AreEqual(MessageType.AckMessage, msg.Type);
 
-            var realMsg = msg as ClientAckMessage;
+            var realMsg = msg as ClientAckMessage<JsonElement>;
 
             Assert.AreEqual("/google", realMsg.Namespace);
             Assert.AreEqual(15, realMsg.Id);
@@ -233,10 +234,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Error()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "44{\"message\":\"Authentication error2\"}");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "44{\"message\":\"Authentication error2\"}");
             Assert.AreEqual(MessageType.ErrorMessage, msg.Type);
 
-            var result = msg as ErrorMessage;
+            var result = msg as ErrorMessage<JsonElement>;
 
             Assert.IsNull(result.Namespace);
             Assert.AreEqual("Authentication error2", result.Message);
@@ -245,10 +246,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceError()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "44/message,{\"message\":\"Authentication error\"}");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "44/message,{\"message\":\"Authentication error\"}");
             Assert.AreEqual(MessageType.ErrorMessage, msg.Type);
 
-            var result = msg as ErrorMessage;
+            var result = msg as ErrorMessage<JsonElement>;
 
             Assert.AreEqual("/message", result.Namespace);
             Assert.AreEqual("Authentication error", result.Message);
@@ -257,10 +258,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Binary()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "451-[\"1 params\",{\"_placeholder\":true,\"num\":0}]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "451-[\"1 params\",{\"_placeholder\":true,\"num\":0}]");
             Assert.AreEqual(MessageType.BinaryMessage, msg.Type);
 
-            var realMsg = msg as BinaryMessage;
+            var realMsg = msg as BinaryMessage<JsonElement>;
 
             Assert.IsTrue(string.IsNullOrEmpty(realMsg.Namespace));
             Assert.AreEqual(1, realMsg.BinaryCount);
@@ -273,10 +274,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceBinary()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "451-/why-ve,[\"1 params\",{\"_placeholder\":true,\"num\":0}]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "451-/why-ve,[\"1 params\",{\"_placeholder\":true,\"num\":0}]");
             Assert.AreEqual(MessageType.BinaryMessage, msg.Type);
 
-            var realMsg = msg as BinaryMessage;
+            var realMsg = msg as BinaryMessage<JsonElement>;
 
             Assert.AreEqual("/why-ve", realMsg.Namespace);
             Assert.AreEqual(1, realMsg.BinaryCount);
@@ -289,10 +290,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceBinaryWithId()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "451-/why-ve,30[\"1 params\",{\"_placeholder\":true,\"num\":0}]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "451-/why-ve,30[\"1 params\",{\"_placeholder\":true,\"num\":0}]");
             Assert.AreEqual(MessageType.BinaryMessage, msg.Type);
 
-            var realMsg = msg as BinaryMessage;
+            var realMsg = msg as BinaryMessage<JsonElement>;
 
             Assert.AreEqual("/why-ve", realMsg.Namespace);
             Assert.AreEqual(1, realMsg.BinaryCount);
@@ -306,10 +307,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void BinaryAck()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "461-6[{\"_placeholder\":true,\"num\":0}]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "461-6[{\"_placeholder\":true,\"num\":0}]");
             Assert.AreEqual(MessageType.BinaryAckMessage, msg.Type);
 
-            var realMsg = msg as ClientBinaryAckMessage;
+            var realMsg = msg as ClientBinaryAckMessage<JsonElement>;
 
             Assert.IsNull(realMsg.Namespace);
             Assert.AreEqual(1, realMsg.BinaryCount);
@@ -322,10 +323,10 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceBinaryAck()
         {
-            var msg = MessageFactory.CreateMessage(EngineIO.V4, "461-/name-space,6[{\"_placeholder\":true,\"num\":0}]");
+            var msg = MessageFactory<JsonElement>.CreateMessage(EngineIO.V4, new SystemTextJsonSerializer(), "461-/name-space,6[{\"_placeholder\":true,\"num\":0}]");
             Assert.AreEqual(MessageType.BinaryAckMessage, msg.Type);
 
-            var realMsg = msg as ClientBinaryAckMessage;
+            var realMsg = msg as ClientBinaryAckMessage<JsonElement>;
 
             Assert.AreEqual("/name-space", realMsg.Namespace);
             Assert.AreEqual(1, realMsg.BinaryCount);

--- a/tests/SocketIOClient.UnitTests/MessageTests/MessageWriteTest.cs
+++ b/tests/SocketIOClient.UnitTests/MessageTests/MessageWriteTest.cs
@@ -3,6 +3,7 @@ using SocketIOClient.Messages;
 using SocketIOClient.Transport;
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace SocketIOClient.UnitTests.MessageTests
 {
@@ -12,7 +13,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Ping()
         {
-            var msg = new PingMessage();
+            var msg = new PingMessage<JsonElement>();
             string text = msg.Write();
             Assert.AreEqual("2", text);
         }
@@ -20,7 +21,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Pong()
         {
-            var msg = new PongMessage();
+            var msg = new PongMessage<JsonElement>();
             string text = msg.Write();
             Assert.AreEqual("3", text);
         }
@@ -28,7 +29,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio4Connected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V4
             };
@@ -39,7 +40,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio4NamespaceConnected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V4,
                 Namespace = "/microsoft"
@@ -51,7 +52,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3WsWithoutQueryConnected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V3,
                 Protocol = TransportProtocol.WebSocket,
@@ -64,7 +65,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3WsWith1ParamConnected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V3,
                 Protocol = TransportProtocol.WebSocket,
@@ -81,7 +82,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3WsWith2ParamConnected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V3,
                 Protocol = TransportProtocol.WebSocket,
@@ -99,7 +100,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3PollingWithoutQueryConnected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V3,
                 Protocol = TransportProtocol.Polling,
@@ -112,7 +113,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3PollingWith1ParamConnected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V3,
                 Protocol = TransportProtocol.Polling,
@@ -129,7 +130,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Eio3PollingWith2ParamConnected()
         {
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>  
             {
                 EIO = EngineIO.V3,
                 Protocol = TransportProtocol.Polling,
@@ -146,7 +147,7 @@ namespace SocketIOClient.UnitTests.MessageTests
 
         [TestMethod]
         public void Eio4_Auth_Query_Namespace_Should_Include_Auth_Namespace(){
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V4,
                 Protocol = TransportProtocol.Polling,
@@ -164,7 +165,7 @@ namespace SocketIOClient.UnitTests.MessageTests
 
         [TestMethod]
         public void Eio4_Auth_Should_Include_Auth(){
-            var msg = new ConnectedMessage
+            var msg = new ConnectedMessage<JsonElement>
             {
                 EIO = EngineIO.V4,
                 Protocol = TransportProtocol.Polling,
@@ -177,7 +178,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Disconnected()
         {
-            var msg = new DisconnectedMessage();
+            var msg = new DisconnectedMessage<JsonElement>();
             string text = msg.Write();
             Assert.AreEqual("41", text);
         }
@@ -185,7 +186,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceDisconnected()
         {
-            var msg = new DisconnectedMessage
+            var msg = new DisconnectedMessage<JsonElement>
             {
                 Namespace = "/hello-world"
             };
@@ -196,7 +197,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Event0Param()
         {
-            var msg = new EventMessage
+            var msg = new EventMessage<JsonElement>
             {
                 Event = "event name",
             };
@@ -207,7 +208,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Event1Param()
         {
-            var msg = new EventMessage
+            var msg = new EventMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[\"socket.io\"]"
@@ -219,7 +220,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceEvent0Param()
         {
-            var msg = new EventMessage
+            var msg = new EventMessage<JsonElement>
             {
                 Event = "event name",
                 Namespace = "/test"
@@ -231,7 +232,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceEvent1Param()
         {
-            var msg = new EventMessage
+            var msg = new EventMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[1234]",
@@ -244,7 +245,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Ack()
         {
-            var msg = new ClientAckMessage
+            var msg = new ClientAckMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[1989]",
@@ -257,7 +258,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceAck()
         {
-            var msg = new ClientAckMessage
+            var msg = new ClientAckMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[1989]",
@@ -271,7 +272,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void ServerAckWihtoutJson()
         {
-            var msg = new ServerAckMessage
+            var msg = new ServerAckMessage<JsonElement>
             {
                 Id = 8964
             };
@@ -282,7 +283,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceServerAck()
         {
-            var msg = new ServerAckMessage
+            var msg = new ServerAckMessage<JsonElement>
             {
                 Json = "[1989,\"test\",false]",
                 Id = 8964,
@@ -295,7 +296,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void Binary()
         {
-            var msg = new BinaryMessage
+            var msg = new BinaryMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[1989]",
@@ -312,7 +313,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceBinary()
         {
-            var msg = new BinaryMessage
+            var msg = new BinaryMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[1989]",
@@ -330,7 +331,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void BinaryAck()
         {
-            var msg = new ClientBinaryAckMessage
+            var msg = new ClientBinaryAckMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[1989]",
@@ -352,7 +353,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceBinaryAck()
         {
-            var msg = new ClientBinaryAckMessage
+            var msg = new ClientBinaryAckMessage<JsonElement>
             {
                 Event = "event name",
                 Json = "[1989]",
@@ -375,7 +376,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void ServerBinaryAck()
         {
-            var msg = new ServerBinaryAckMessage
+            var msg = new ServerBinaryAckMessage<JsonElement>
             {
                 Json = "[1989,\"test\",false]",
                 Id = 185,
@@ -391,7 +392,7 @@ namespace SocketIOClient.UnitTests.MessageTests
         [TestMethod]
         public void NamespaceServerBinaryAck()
         {
-            var msg = new ServerBinaryAckMessage
+            var msg = new ServerBinaryAckMessage<JsonElement>
             {
                 Id = 185,
                 Namespace = "/q",

--- a/tests/SocketIOClient.UnitTests/SocketIOResponseTest.cs
+++ b/tests/SocketIOClient.UnitTests/SocketIOResponseTest.cs
@@ -16,7 +16,7 @@ namespace SocketIOClient.UnitTests
         public void TestToString(string json)
         {
             var array = JsonDocument.Parse(json).RootElement.EnumerateArray().ToList();
-            var response = new SocketIOResponse(array, null);
+            var response = new SocketIOResponse<JsonElement>(array, null);
             Assert.AreEqual(json, response.ToString());
         }
     }

--- a/tests/SocketIOClient.UnitTests/SocketIOTest.cs
+++ b/tests/SocketIOClient.UnitTests/SocketIOTest.cs
@@ -15,6 +15,7 @@ using SocketIOClient.Messages;
 using SocketIOClient.Transport;
 using SocketIOClient.Transport.Http;
 using SocketIOClient.Transport.WebSockets;
+using System.Text.Json;
 
 [assembly: Parallelize(Workers = 8, Scope = ExecutionScope.ClassLevel)]
 
@@ -523,7 +524,7 @@ namespace SocketIOClient.UnitTests
                         },
                         m =>
                         {
-                            var msg = (EventMessage)m;
+                            var msg = (EventMessage<JsonElement>)m;
                             var text = System.Text.Json.JsonSerializer.Serialize(
                                 "hello world 你好🌍🌏🌎 hello world");
                             return msg.Event == "1 param" && msg.Json == $"[{text}]";
@@ -536,7 +537,7 @@ namespace SocketIOClient.UnitTests
                         },
                         m =>
                         {
-                            var msg = (BinaryMessage)m;
+                            var msg = (BinaryMessage<JsonElement>)m;
                             return msg.Event == "test-2"
                                    && msg.Json == "[{\"_placeholder\":true,\"num\":0}]"
                                    && msg.OutgoingBytes[0]

--- a/tests/SocketIOClient.UnitTests/Transport/Http/HttpTransportTest.cs
+++ b/tests/SocketIOClient.UnitTests/Transport/Http/HttpTransportTest.cs
@@ -134,7 +134,7 @@ namespace SocketIOClient.UnitTests.Transport.Http
             var mockHttpPollingHandler = new Mock<IHttpPollingHandler>();
             mockHttpPollingHandler.SetupProperty(h => h.OnTextReceived);
 
-            _ = new HttpTransport<JsonElement>(new TransportOptions { EIO = EngineIO.V4, Auth = auth }, mockHttpPollingHandler.Object, new SystemTextJsonSerializer());
+            _ = new HttpTransport<JsonElement>(new TransportOptions { EIO = EngineIO.V4, Auth = auth }, mockHttpPollingHandler.Object, new SystemTextJsonSerializer()) { Namespace=ns};
             mockHttpPollingHandler.Object.OnTextReceived(
                 "0{\"sid\":\"LgtKYhIy7tUzKHH9AAAB\",\"upgrades\":[\"websocket\"],\"pingInterval\":10000,\"pingTimeout\":5000}");
 


### PR DESCRIPTION
### Issue with current version
When the JSON with depth more than default depth of 64 was being received it was throwing error "MaxDepth of 64 has been exceeded" even though while passing custom Newtonsoft.Json Serializer with max depth set to 512 (or anything greater than 64)
### Cause
The custom serializer being passed after SocketIO class initialization was not being utilized to read the incoming data, it was used to emit mostly.
### Fix
Added functions to IJsonSerializer and implemented in NewtonsoftJsonSerializer and SystemTextJsonSerializer so that even while reading from incoming data serializer is being used, SocketIO class had to made generic, but there is a non generic SocketIO class too which uses JsonElement as type and SystemTextJsonSerializer  as default serializer.