### PR TITLE
:bug: Packet Id can be modified during parallel operations

### DIFF
--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -705,8 +705,9 @@ namespace SocketIOClient
             Action<SocketIOResponse> ack,
             params object[] data)
         {
-            _ackActionHandlers.Add(++_packetId, ack);
-            await EmitForAck(eventName, _packetId, cancellationToken, data).ConfigureAwait(false);
+            var msgPacketId = ++_packetId;
+            _ackActionHandlers.Add(msgPacketId, ack);
+            await EmitForAck(eventName, msgPacketId, cancellationToken, data).ConfigureAwait(false);
         }
 
         private async Task EmitAsync(
@@ -715,8 +716,9 @@ namespace SocketIOClient
             Func<SocketIOResponse, Task> ack,
             params object[] data)
         {
-            _ackFuncHandlers.Add(++_packetId, ack);
-            await EmitForAck(eventName, _packetId, cancellationToken, data).ConfigureAwait(false);
+            var msgPacketId = ++_packetId;
+            _ackFuncHandlers.Add(msgPacketId, ack);
+            await EmitForAck(eventName, msgPacketId, cancellationToken, data).ConfigureAwait(false);
         }
 
 

--- a/tests/SocketIOClient.UnitTests/SocketIOClient.UnitTests.csproj
+++ b/tests/SocketIOClient.UnitTests/SocketIOClient.UnitTests.csproj
@@ -4,18 +4,20 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <AssemblyOriginatorKeyFile>../../src/SocketIOClient/SocketIOClient.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
   </ItemGroup>
 

--- a/tests/SocketIOClient.UnitTests/SocketIOTests.cs
+++ b/tests/SocketIOClient.UnitTests/SocketIOTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using SocketIOClient.Transport;
+
+namespace SocketIOClient.UnitTests;
+
+[TestClass]
+public class SocketIOTests
+{
+    [TestMethod]
+    public void EmitAckAction_InParallel_PacketIdShouldBeThreadSafe()
+    {
+        const int count = 100;
+        var seq = new List<int>();
+        using var io = new SocketIO("http://localhost");
+        io.Transport = Substitute.For<ITransport>();
+
+        Parallel.For(0, count, i =>
+        {
+            io.EmitAsync(i.ToString(), _ => seq.Add(i)).GetAwaiter().GetResult();
+        });
+
+        foreach (var v in io.AckActionHandlers.Values)
+        {
+            v(null);
+        }
+
+        io.AckActionHandlers.Should().HaveCount(count);
+        io.AckActionHandlers.Keys.Should().BeEquivalentTo(seq);
+    }
+    
+    
+    [TestMethod]
+    public async Task EmitAckFunc_InParallel_PacketIdShouldBeThreadSafe()
+    {
+        const int count = 100;
+        var seq = new List<int>();
+        using var io = new SocketIO("http://localhost");
+        io.Transport = Substitute.For<ITransport>();
+
+        Parallel.For(0, count, i =>
+        {
+            io.EmitAsync(i.ToString(), _ =>
+            {
+                seq.Add(i);
+                return Task.CompletedTask;
+            }).GetAwaiter().GetResult();
+        });
+
+        foreach (var v in io.AckFuncHandlers.Values)
+        {
+            await v(null);
+        }
+
+        io.AckFuncHandlers.Should().HaveCount(count);
+        io.AckFuncHandlers.Keys.Should().BeEquivalentTo(seq);
+    }
+}


### PR DESCRIPTION
When executing is performed in parallel the _packetId might get updated prior to being sent across the wire. This modification ensures that the same id is used to store response handles and the emitted event.

Sorry this was edited in the web UI.

I'm pretty sure I'm currently hitting this bug and would appreciate a release with a fix :D