### PR TITLE
socket.io-client-sharp 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2024-20-02
+
+### Changed
+
+- Changed all projects to target both .net standard 2.0 and .net 4.6.2
+  - Except `SocketIO.Serializer.MessagePack`
+- Changed `SocketIO` constructor to include `ISerializer`
+  - `ISerializer` defaults to first available based on target framework
+    - .net 4.6.2 `SocketIO.Serializer.NewtonsoftJson`
+    - .net Standard 2.0+ `SocketIO.Serializer.SystemTextJson`
+- Changed `EventHandlers` delegates to invoke `object` arrays instead of `JsonElement` arrays
+
 ## [3.1.1] - 2023-09-05
 
 ### Added
@@ -168,7 +180,7 @@ client.Socket = new ClientWebSocketManaged();
 
 ## [2.2.4] - 2021-6-24
 
-SocketIOClient  
+SocketIOClient
 SocketIOClient.Windows7
 
 ### Changed
@@ -181,7 +193,7 @@ SocketIOClient.Windows7
 
 ## [2.2.3] - 2021-6-15
 
-SocketIOClient  
+SocketIOClient
 SocketIOClient.Windows7
 
 ### Changed
@@ -197,7 +209,7 @@ SocketIOClient.Windows7
 
 ## [2.2.2] - 2021-6-7
 
-SocketIOClient  
+SocketIOClient
 SocketIOClient.Windows7
 
 ### Changed
@@ -206,7 +218,7 @@ SocketIOClient.Windows7
 
 ## [2.2.1] - 2021-6-5
 
-SocketIOClient  
+SocketIOClient
 SocketIOClient.Windows7
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ An elegant socket.io client for .NET, it supports socket.io server v2/v3/v4, and
   - [Windows 7 Support](#windows-7-support)
   - [Xamarin](#xamarin)
 - [Breaking changes](#breaking-changes)
-  - [Breaking changes in 4.0.0](#breaking-changes-in-400)
 - [Change log](#change-log)
-- [Sponsors](#Sponsors)
+- [Thank You](#thanks)
 
 # Quick start
 
@@ -200,7 +199,7 @@ Based on the Target Framework you used to install the package, the default json 
 
 | Target Framework | Serializer | Package | Example |
 |------------------|------------|---------|---------|
-| .NET Standard 2.0 | System.Text.Json | `SocketIO.Serializer.NewtonsoftJson` | `client.Serializer = new SystemTextJsonSerializer(new JsonSerializerOptions { PropertyNameCaseInsensitive = true });` |
+| .NET Standard 2.0 | System.Text.Json | `SocketIO.Serializer.NewtonsoftJson` | ```client.Serializer = new SystemTextJsonSerializer(new JsonSerializerOptions { PropertyNameCaseInsensitive = true });``` |
 | .NET Framework 4.6.2 | Newtonsoft.Json | `SocketIO.Serializer.NewtonsoftJson` | `client.Serializer = new NewtonsoftJsonSerializer(new JsonSerializerSettings { ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() } });` |
 | .NET Standard 2.0 | Message Pack | `SocketIO.Serializer.MessagePack` | `client.Serializer = new SocketIOMessagePackSerializer();` |
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,17 @@ An elegant socket.io client for .NET, it supports socket.io server v2/v3/v4, and
 [![Target Framework](https://img.shields.io/badge/Target%20Framework-.NET%20Standard%202.0-%237014e8)](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support)
 [![NuGet](https://img.shields.io/nuget/dt/SocketIOClient)](https://www.nuget.org/packages/SocketIOClient)
 
-# Table of Contents
+## Table of Contents
 
 - [Quick start](#quick-start)
   - [Options](#options)
   - [Ack](#ack)
   - [Binary messages](#binary-messages)
-  - [JsonSerializer](#jsonserializer)
-  - [ClientWebSocket Options](#clientwebsocket-options)
+  - [Json Serializer Options](#jsonserializer)
   - [Windows 7 Support](#windows-7-support)
   - [Xamarin](#xamarin)
 - [Breaking changes](#breaking-changes)
-  - [Breaking changes in 3.1.0](#breaking-changes-in-310)
+  - [Breaking changes in 4.0.0](#breaking-changes-in-400)
 - [Change log](#change-log)
 - [Sponsors](#Sponsors)
 
@@ -46,7 +45,7 @@ client.On("test", response =>
     // You can print the returned data first to decide what to do next.
     // output: ["ok",{"id":1,"name":"tom"}]
     Console.WriteLine(response);
-    
+
     // Get the first data in the response
     string text = response.GetValue<string>();
     // Get the second data in the response
@@ -137,7 +136,7 @@ client.On("ack2", async response =>
     Console.WriteLine(response);
     int a = response.GetValue<int>();
     int b = response.GetValue<int>(1);
-    
+
     await response.CallbackAsync(b, a);
 });
 ```
@@ -195,19 +194,29 @@ client.On("new files", response =>
 });
 ```
 
-## Serializer
+## JsonSerializer
 
-The library uses System.Text.Json to serialize and deserialize json by default, If you want to change JsonSerializerOptions, you can do this:
+Based on the Target Framework you used to install the package, the default json serializer will be imported for you.
+
+| Target Framework | Serializer | Package | Example |
+|------------------|------------|---------|---------|
+| .NET Standard 2.0 | System.Text.Json | `SocketIO.Serializer.NewtonsoftJson` | `client.Serializer = new SystemTextJsonSerializer(new JsonSerializerOptions { PropertyNameCaseInsensitive = true });` |
+| .NET Framework 4.6.2 | Newtonsoft.Json | `SocketIO.Serializer.NewtonsoftJson` | `client.Serializer = new NewtonsoftJsonSerializer(new JsonSerializerSettings { ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() } });` |
+| .NET Standard 2.0 | Message Pack | `SocketIO.Serializer.MessagePack` | `client.Serializer = new SocketIOMessagePackSerializer();` |
+
+This table assumes that you're using System.Text.Json for .NET Standard 2.0 and Newtonsoft.Json for .NET Framework 4.6.2, but you can use either serializer with either target framework if you prefer.
+
+If you want to change JsonSerializerOptions, you can do this:
 
 ```cs
-var client = new SocketIO("http://localhost:11000/");
-client.Serializer = new SystemTextJsonSerializer(new JsonSerializerOptions
+serializer = new SystemTextJsonSerializer(new JsonSerializerOptions
 {
     PropertyNameCaseInsensitive = true
 });
+var client = new SocketIO("http://localhost:11000/", serializer: serializer);
 ```
 
-Of course you can also use Newtonsoft.Json library, for this, you need to install `SocketIO.Serializer.NewtonsoftJson` 
+Of course you can also use Newtonsoft.Json library, for this, you need to install `SocketIO.Serializer.NewtonsoftJson`
 dependency.
 
 ```cs
@@ -265,25 +274,31 @@ For Xamarin.Android you should add the following code:
 
 I don't know the specific exceptions of Xamarin.iOS. Welcome to create a pr and update this document. thanks :)
 
+# Breaking Changes
+
+- The default serializer might change depending on the target framework your project is targeting by default.
+- Any of the serializers should work for either Target Framework (with the exception of Message Pack as it is .NET Standard 2.0+)
+- See [Json Serializer Options](#jsonserializer) for more details
+
 # Change log
 
-## [3.1.0] - 2023-08-25
+## [4.0.0] - 2024-20-02
 
-### Added
+### Changed
 
-- `SocketIO.Serializer.MessagePack` serializer
-- `SocketIO.Serializer.NewtonsoftJson` serializer
-- `SocketIO.Serializer.SystemTextJson` serializer
-
-### Removed
-
-- `SocketIOClient.Newtonsoft.Json` serializer
+- Changed all projects to target both .net standard 2.0 and .net 4.6.2
+  - Except `SocketIO.Serializer.MessagePack`
+- Changed `SocketIO` constructor to include `ISerializer`
+  - `ISerializer` defaults to first available based on target framework
+    - .net 4.6.2 `SocketIO.Serializer.NewtonsoftJson`
+    - .net Standard 2.0+ `SocketIO.Serializer.SystemTextJson`
+- Changed `EventHandlers` delegates to invoke `object` arrays instead of `JsonElement` arrays
 
 [See more](./CHANGELOG.md)
 
 # Thanks
 
-[<img src="https://socket.io/images/logo.svg" width=100px/>](https://github.com/socketio/socket.io) [<img src="https://github.com/darrachequesne.png" width=100px/>](https://github.com/socketio/socket.io) 
+[<img src="https://socket.io/images/logo.svg" width=100px/>](https://github.com/socketio/socket.io) [<img src="https://github.com/darrachequesne.png" width=100px/>](https://github.com/socketio/socket.io)
 
 Thank [socket.io](https://socket.io/) and [darrachequesne](https://github.com/darrachequesne) for sponsoring the project on [Open Collective](https://opencollective.com/socketio/expenses/).
 

--- a/src/SocketIO.Core/SocketIO.Core.csproj
+++ b/src/SocketIO.Core/SocketIO.Core.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../SocketIOClient/SocketIOClient.snk</AssemblyOriginatorKeyFile>
-    <Version>3.1.1</Version>
+    <Version>4.0.0</Version>
     <PackageProjectUrl>https://github.com/doghappy/socket.io-client-csharp</PackageProjectUrl>
     <Authors>doghappy</Authors>
     <RepositoryUrl>https://github.com/doghappy/socket.io-client-csharp</RepositoryUrl>

--- a/src/SocketIO.Serializer.Core/SocketIO.Serializer.Core.csproj
+++ b/src/SocketIO.Serializer.Core/SocketIO.Serializer.Core.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../SocketIOClient/SocketIOClient.snk</AssemblyOriginatorKeyFile>
-    <Version>3.1.1</Version>
+    <Version>4.0.0</Version>
     <Authors>doghappy</Authors>
     <PackageProjectUrl>https://github.com/doghappy/socket.io-client-csharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/doghappy/socket.io-client-csharp</RepositoryUrl>

--- a/src/SocketIO.Serializer.MessagePack/SocketIO.Serializer.MessagePack.csproj
+++ b/src/SocketIO.Serializer.MessagePack/SocketIO.Serializer.MessagePack.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../SocketIOClient/SocketIOClient.snk</AssemblyOriginatorKeyFile>
-    <Version>3.1.2</Version>
+    <Version>4.0.0</Version>
     <Authors>doghappy</Authors>
     <PackageProjectUrl>https://github.com/doghappy/socket.io-client-csharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/doghappy/socket.io-client-csharp</RepositoryUrl>
@@ -14,12 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MessagePack" Version="2.5.124" />
     <ProjectReference Include="..\SocketIO.Core\SocketIO.Core.csproj" />
     <ProjectReference Include="..\SocketIO.Serializer.Core\SocketIO.Serializer.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.5.124" />
   </ItemGroup>
 
 </Project>

--- a/src/SocketIO.Serializer.NewtonsoftJson/SocketIO.Serializer.NewtonsoftJson.csproj
+++ b/src/SocketIO.Serializer.NewtonsoftJson/SocketIO.Serializer.NewtonsoftJson.csproj
@@ -1,18 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../SocketIOClient/SocketIOClient.snk</AssemblyOriginatorKeyFile>
-    <Version>3.1.1</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\SocketIO.Core\SocketIO.Core.csproj" />
     <ProjectReference Include="..\SocketIO.Serializer.Core\SocketIO.Serializer.Core.csproj" />
   </ItemGroup>

--- a/src/SocketIO.Serializer.SystemTextJson/SocketIO.Serializer.SystemTextJson.csproj
+++ b/src/SocketIO.Serializer.SystemTextJson/SocketIO.Serializer.SystemTextJson.csproj
@@ -1,20 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../SocketIOClient/SocketIOClient.snk</AssemblyOriginatorKeyFile>
-    <Version>3.1.1</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
     <ProjectReference Include="..\SocketIO.Core\SocketIO.Core.csproj" />
     <ProjectReference Include="..\SocketIO.Serializer.Core\SocketIO.Serializer.Core.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
-  </ItemGroup>
-
 </Project>

--- a/src/SocketIOClient/EventHandlers.cs
+++ b/src/SocketIOClient/EventHandlers.cs
@@ -1,17 +1,16 @@
 ﻿using System.Collections.Generic;
-using System.Text.Json;
 
 namespace SocketIOClient
 {
     public delegate void OnAnyHandler(string eventName, SocketIOResponse response);
     public delegate void OnOpenedHandler(string sid, int pingInterval, int pingTimeout);
     //public delegate void OnDisconnectedHandler(string sid, int pingInterval, int pingTimeout);
-    public delegate void OnAck(int packetId, List<JsonElement> array);
-    public delegate void OnBinaryAck(int packetId, int totalCount, List<JsonElement> array);
-    public delegate void OnBinaryReceived(int packetId, int totalCount, string eventName, List<JsonElement> array);
+    public delegate void OnAck(int packetId, List<object> array);
+    public delegate void OnBinaryAck(int packetId, int totalCount, List<object> array);
+    public delegate void OnBinaryReceived(int packetId, int totalCount, string eventName, List<object> array);
     public delegate void OnDisconnected();
     public delegate void OnError(string error);
-    public delegate void OnEventReceived(int packetId, string eventName, List<JsonElement> array);
+    public delegate void OnEventReceived(int packetId, string eventName, List<object> array);
     public delegate void OnOpened(string sid, int pingInterval, int pingTimeout);
     public delegate void OnPing();
     public delegate void OnPong();

--- a/src/SocketIOClient/SocketIOClient.csproj
+++ b/src/SocketIOClient/SocketIOClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2;net462</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
 		<AssemblyName>SocketIOClient</AssemblyName>
 		<RootNamespace>SocketIOClient</RootNamespace>
 		<Authors>doghappy</Authors>
@@ -11,7 +11,7 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>socket.io-client</PackageTags>
 		<RepositoryType>github</RepositoryType>
-		<Version>3.1.1</Version>
+		<Version>4.0.0</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>SocketIOClient.snk</AssemblyOriginatorKeyFile>
@@ -31,9 +31,16 @@
 		<Reference Include="System.Net.Http" />
 	</ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+        <ProjectReference Include="..\SocketIO.Serializer.SystemTextJson\SocketIO.Serializer.SystemTextJson.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)'=='net462'">
+        <ProjectReference Include="..\SocketIO.Serializer.NewtonsoftJson\SocketIO.Serializer.NewtonsoftJson.csproj" />
+    </ItemGroup>
+
 	<ItemGroup>
-	  <ProjectReference Include="..\SocketIO.Serializer.Core\SocketIO.Serializer.Core.csproj" />
-	  <ProjectReference Include="..\SocketIO.Serializer.SystemTextJson\SocketIO.Serializer.SystemTextJson.csproj" />
+		<ProjectReference Include="..\SocketIO.Serializer.Core\SocketIO.Serializer.Core.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/SocketIOClient/SocketIOResponse.cs
+++ b/src/SocketIOClient/SocketIOResponse.cs
@@ -1,11 +1,7 @@
-﻿using System;
+﻿using SocketIO.Core;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using SocketIO.Core;
 
 namespace SocketIOClient
 {

--- a/tests/SocketIOClient.IntegrationTests.Net472/SocketIOClient.IntegrationTests.Net472.csproj
+++ b/tests/SocketIOClient.IntegrationTests.Net472/SocketIOClient.IntegrationTests.Net472.csproj
@@ -96,7 +96,7 @@
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />

--- a/tests/SocketIOClient.IntegrationTests.Net472/SocketIOClient.IntegrationTests.Net472.csproj
+++ b/tests/SocketIOClient.IntegrationTests.Net472/SocketIOClient.IntegrationTests.Net472.csproj
@@ -167,6 +167,10 @@
       <Project>{93cdcf52-263c-4ff9-b55a-bbdfe315e1bb}</Project>
       <Name>SocketIO.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\SocketIO.Serializer.Core\SocketIO.Serializer.Core.csproj">
+      <Project>{2D5C3E28-CB0F-40BF-AEBF-FC1EF7E07F03}</Project>
+      <Name>SocketIO.Serializer.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SocketIOClient.IntegrationTests.Common\SocketIOClient.IntegrationTests.Common.csproj">
       <Project>{8c62bd1e-9f14-4170-8e19-29a39996aaa2}</Project>
       <Name>SocketIOClient.IntegrationTests.Common</Name>

--- a/tests/SocketIOClient.IntegrationTests.Net472/app.config
+++ b/tests/SocketIOClient.IntegrationTests.Net472/app.config
@@ -52,7 +52,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/SocketIOClient.IntegrationTests/SocketIOClient.IntegrationTests.csproj
+++ b/tests/SocketIOClient.IntegrationTests/SocketIOClient.IntegrationTests.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <ProjectReference Include="..\..\src\SocketIO.Serializer.MessagePack\SocketIO.Serializer.MessagePack.csproj" />
+    <ProjectReference Include="..\..\src\SocketIO.Serializer.SystemTextJson\SocketIO.Serializer.SystemTextJson.csproj" />
     <ProjectReference Include="..\SocketIO.Serializer.Tests.Models\SocketIO.Serializer.Tests.Models.csproj" />
     <ProjectReference Include="..\SocketIOClient.IntegrationTests.Common\SocketIOClient.IntegrationTests.Common.csproj" />
     <ProjectReference Include="..\..\src\SocketIOClient\SocketIOClient.csproj" />

--- a/tests/SocketIOClient.IntegrationTests/SocketIOTests.cs
+++ b/tests/SocketIOClient.IntegrationTests/SocketIOTests.cs
@@ -1,21 +1,13 @@
 ﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SocketIO.Core;
+using SocketIO.Serializer.Tests.Models;
+using SocketIOClient.Transport;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Ports;
 using System.Linq;
 using System.Net.Sockets;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using System.Text.Unicode;
 using System.Threading.Tasks;
-using SocketIOClient.Transport;
-using SocketIO.Core;
-using SocketIO.Serializer.SystemTextJson;
-using SocketIO.Serializer.Tests.Models;
 
 namespace SocketIOClient.IntegrationTests
 {

--- a/tests/SocketIOClient.IntegrationTests/Utils/SerializerHelper.cs
+++ b/tests/SocketIOClient.IntegrationTests/Utils/SerializerHelper.cs
@@ -1,10 +1,9 @@
+using MessagePack.Resolvers;
+using SocketIO.Serializer.MessagePack;
+using SocketIO.Serializer.SystemTextJson;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
-using MessagePack.Resolvers;
-using SocketIO.Core;
-using SocketIO.Serializer.MessagePack;
-using SocketIO.Serializer.SystemTextJson;
 
 namespace SocketIOClient.IntegrationTests.Utils;
 
@@ -14,12 +13,12 @@ public static class SerializerHelper
     {
         io.Serializer = new SocketIOMessagePackSerializer(ContractlessStandardResolver.Options);
     }
-    
+
     public static void ConfigureSystemTextJsonSerializer(this SocketIO io, JsonSerializerOptions options)
     {
         io.Serializer = new SystemTextJsonSerializer(options);
     }
-    
+
     public static void ConfigureSystemTextJsonSerializerForEmitting1Parameter(this SocketIO io)
     {
         io.ConfigureSystemTextJsonSerializer(new JsonSerializerOptions


### PR DESCRIPTION
- Closes #358 
- Changed all projects to target both .net standard 2.0 and .net 4.6.2
  - Except `SocketIO.Serializer.MessagePack`
- Changed `SocketIO` constructor to include `ISerializer`
  - `ISerializer` defaults to first available based on target framework
    - .net 4.6.2 `SocketIO.Serializer.NewtonsoftJson`
    - .net Standard 2.0+ `SocketIO.Serializer.SystemTextJson`
- Changed `EventHandlers` delegates to invoke `object` arrays instead of `JsonElement` arrays