### PR TITLE
ConnectAsync overload with CancellationToken parameter

### DIFF
--- a/src/SocketIO.Serializer.MessagePack/SocketIO.Serializer.MessagePack.csproj
+++ b/src/SocketIO.Serializer.MessagePack/SocketIO.Serializer.MessagePack.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.5.140" />
+    <PackageReference Include="MessagePack" Version="2.5.171" />
   </ItemGroup>
 
 </Project>

--- a/src/SocketIO.Serializer.SystemTextJson/SocketIO.Serializer.SystemTextJson.csproj
+++ b/src/SocketIO.Serializer.SystemTextJson/SocketIO.Serializer.SystemTextJson.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -408,6 +408,7 @@ namespace SocketIOClient
 
         private readonly SemaphoreSlim _connectingLock = new(1, 1);
         private CancellationTokenSourceWrapper _connCts;
+        private bool isUserManagedCancellationToken = false;
 
         private void ConnectInBackground()
         {
@@ -417,6 +418,8 @@ namespace SocketIOClient
 
         public async Task ConnectAsync()
         {
+            isUserManagedCancellationToken = false;
+
             await _connectingLock.WaitAsync().ConfigureAwait(false);
             try
             {
@@ -455,8 +458,11 @@ namespace SocketIOClient
                 _connectingLock.Release();
             }
         }
+
         public async Task ConnectAsync(CancellationToken cancellationToken)
         {
+            isUserManagedCancellationToken = true;
+
             await _connectingLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
@@ -469,8 +475,10 @@ namespace SocketIOClient
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        break;
+                        throw new OperationCanceledException($"Connection to server '{ServerUri}' was canceled.");
                     }
+
+                    if (Connected) break;
 
                     if (_backgroundException != null)
                     {
@@ -529,7 +537,10 @@ namespace SocketIOClient
 
             Id = msg.Sid;
             Connected = true;
-            _connCts.Dispose();
+
+            if (!isUserManagedCancellationToken)
+                _connCts.Dispose();
+
             OnConnected.TryInvoke(this, EventArgs.Empty);
             if (_attempts > 0)
             {


### PR DESCRIPTION
In reference to #377, I've added a new overload for the ConnectAsync method that now allows the user to pass a CancellationToken.
This lets the user cancel the connection at any time given before the server has connected.
It prevents the user from waiting a specific amount of time before the connection timeout runs out, and allows for a quick and easy cancellation.

A usage example would be : 

```c#
private static SemaphoreSlim ConnectionSemaphore = new SemaphoreSlim(1);
private static CancellationTokenSource? CancellationTokenSource;

// ...

CancellationTokenSource?.Cancel();
CancellationTokenSource = new CancellationTokenSource();
var cancellationToken = CancellationTokenSource.Token;

try
{
    await ConnectionSemaphore.WaitAsync(cancellationToken);

    var options = new SocketIOOptions
    {
        Reconnection = true,
        ConnectionTimeout = TimeSpan.FromSeconds(30),
        ReconnectionAttempts = 0,
    };

    Client = new SocketIOClient.SocketIO(serverURL, options);

    try
    {
        await Client.ConnectAsync(cancellationToken);
    }
    catch (Exception ex)
    {
        if (ex is OperationCanceledException)
        {
            // Connection canceled
        }
        else
        {
            // Couldn't connect to server, or else
        }
    }
}
finally
{
    ConnectionSemaphore.Release();
}
```