### PR TITLE
Fix issue where 0-byte data is not transmitted via WebSocketTransport

### DIFF
--- a/src/SocketIOClient/Transport/WebSockets/WebSocketTransport.cs
+++ b/src/SocketIOClient/Transport/WebSockets/WebSocketTransport.cs
@@ -41,7 +41,7 @@ namespace SocketIOClient.Transport.WebSockets
                 bytes = buffer;
             }
 
-            int pages = (int)Math.Ceiling(bytes.Length * 1.0 / _sendChunkSize);
+            int pages = bytes.Length == 0 ? 1 : (int)Math.Ceiling(bytes.Length * 1.0 / _sendChunkSize);
             for (int i = 0; i < pages; i++)
             {
                 int offset = i * _sendChunkSize;


### PR DESCRIPTION
### Overview

In the current implementation, sending 0-byte data via `WebSocketTransport` does not actually transmit any byte array.  
As a result:
- A single 0-byte message never reaches the server.
- Sending another 0-byte message subsequently results in a JSON string being received by the server, which can lead to exceptions if the server expects a byte array.

### Root Cause

The issue appears to stem from how `WebSocketTransport` calculates the number of pages to send. If the data length is 0, the number of pages is set to 0, causing the data to be skipped.

### Proposed Fix

I modified the calculation so that even if the data length is 0, the send operation proceeds. This ensures the server correctly receives a 0-byte array.

I tested this change by sending multiple 0-byte messages in succession, and confirmed that the server now consistently receives a 0-byte array.

### Notes

- I have not observed any side effects in my local testing, but if there are concerns about this approach, please let me know, and I will adjust the code accordingly.
- Thank you for developing and maintaining this great library. It's been extremely helpful in my project!

