### PR TITLE
Add missing handshake messages when upgrading to WebSocket, fixes #380

### DIFF
--- a/src/SocketIO.Serializer.Core/ISerializer.cs
+++ b/src/SocketIO.Serializer.Core/ISerializer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using SocketIO.Core;
 
@@ -19,6 +18,7 @@ namespace SocketIO.Serializer.Core
         SerializedItem SerializeConnectedMessage(EngineIO eio, string ns, object auth, IEnumerable<KeyValuePair<string, string>> queries);
 
         SerializedItem SerializePingMessage();
+        SerializedItem SerializePingProbeMessage();
         SerializedItem SerializePongMessage();
         SerializedItem SerializeUpgradeMessage();
     }

--- a/src/SocketIO.Serializer.MessagePack/SocketIOMessagePackSerializer.cs
+++ b/src/SocketIO.Serializer.MessagePack/SocketIOMessagePackSerializer.cs
@@ -257,6 +257,14 @@ namespace SocketIO.Serializer.MessagePack
             };
         }
 
+        public SerializedItem SerializePingProbeMessage()
+        {
+            return new SerializedItem
+            {
+                Text = "2probe"
+            };
+        }
+
         public SerializedItem SerializePongMessage()
         {
             return new SerializedItem

--- a/src/SocketIO.Serializer.NewtonsoftJson/NewtonsoftJsonSerializer.cs
+++ b/src/SocketIO.Serializer.NewtonsoftJson/NewtonsoftJsonSerializer.cs
@@ -220,6 +220,14 @@ namespace SocketIO.Serializer.NewtonsoftJson
             };
         }
 
+        public SerializedItem SerializePingProbeMessage()
+        {
+            return new SerializedItem
+            {
+                Text = "2probe"
+            };
+        }
+
         public SerializedItem SerializePongMessage()
         {
             return new SerializedItem
@@ -309,6 +317,7 @@ namespace SocketIO.Serializer.NewtonsoftJson
                 case MessageType.Ping:
                     break;
                 case MessageType.Pong:
+                    ReadPongMessage(message, text);
                     break;
                 case MessageType.Connected:
                     ReadConnectedMessage(message, text, eio);
@@ -334,6 +343,11 @@ namespace SocketIO.Serializer.NewtonsoftJson
                 default:
                     throw new ArgumentOutOfRangeException(nameof(message.Type), message.Type, null);
             }
+        }
+
+        private static void ReadPongMessage(IMessage message, string text)
+        {
+            message.ReceivedText = text;
         }
 
         private static void ReadOpenedMessage(IMessage message, string text)

--- a/src/SocketIO.Serializer.SystemTextJson/SystemTextJsonSerializer.cs
+++ b/src/SocketIO.Serializer.SystemTextJson/SystemTextJsonSerializer.cs
@@ -220,6 +220,14 @@ namespace SocketIO.Serializer.SystemTextJson
             };
         }
 
+        public SerializedItem SerializePingProbeMessage()
+        {
+            return new SerializedItem
+            {
+                Text = "2probe"
+            };
+        }
+
         public SerializedItem SerializeUpgradeMessage()
         {
             return new SerializedItem
@@ -316,6 +324,7 @@ namespace SocketIO.Serializer.SystemTextJson
                 case MessageType.Ping:
                     break;
                 case MessageType.Pong:
+                    ReadPongMessage(message, text);
                     break;
                 case MessageType.Connected:
                     ReadConnectedMessage(message, text, eio);
@@ -341,6 +350,11 @@ namespace SocketIO.Serializer.SystemTextJson
                 default:
                     throw new ArgumentOutOfRangeException(nameof(message.Type), message.Type, null);
             }
+        }
+
+        private static void ReadPongMessage(IMessage message, string text)
+        {
+            message.ReceivedText = text;
         }
 
         private static void ReadOpenedMessage(IMessage message, string text)

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -320,16 +320,51 @@ namespace SocketIOClient
         {
             var options = NewTransportOptions();
             options.OpenedMessage = openedMessage;
+
             for (var i = 0; i < 3; i++)
             {
-                var transport = (WebSocketTransport)NewTransport(TransportProtocol.WebSocket, options);
-                using var cts = new CancellationTokenSource(Options.ConnectionTimeout);
+                WebSocketTransport transport = (WebSocketTransport)NewTransport(TransportProtocol.WebSocket, options);
+
+                TaskCompletionSource<bool> pongProbeTcs = new();
+                using CancellationTokenSource connectionTimeoutCts = new(Options.ConnectionTimeout);
+                CancellationToken connectionTimeoutToken = connectionTimeoutCts.Token;
+
+                connectionTimeoutToken.Register(() =>
+                {
+                    pongProbeTcs.TrySetException(new TimeoutException("The upgrade operation has timed out!"));
+                });
+
                 try
                 {
-                    await transport.ConnectAsync(cts.Token).ConfigureAwait(false);
-                    var message = Serializer.SerializeUpgradeMessage();
+                    await transport.ConnectAsync(connectionTimeoutToken).ConfigureAwait(false);
+
+                    void pongProbeHandler(IMessage msg)
+                    {
+                        if (msg.Type == MessageType.Pong && msg.ReceivedText == "probe")
+                        {
+                            pongProbeTcs.SetResult(true);
+                        }
+                        else
+                        {
+                            pongProbeTcs.SetException(new Exception($"Unexpected handshake response: '{msg.Type}'"));
+                        }
+                    }
+
+                    transport.OnReceived += pongProbeHandler;
+
+                    SerializedItem message = Serializer.SerializePingProbeMessage();
+
                     await transport
-                        .SendAsync(new List<SerializedItem> { message }, cts.Token)
+                        .SendAsync(new List<SerializedItem> { message }, connectionTimeoutToken)
+                        .ConfigureAwait(false);
+
+                    await pongProbeTcs.Task;
+
+                    transport.OnReceived -= pongProbeHandler;
+
+                    message = Serializer.SerializeUpgradeMessage();
+                    await transport
+                        .SendAsync(new List<SerializedItem> { message }, connectionTimeoutToken)
                         .ConfigureAwait(false);
 
                     Transport.Dispose();


### PR DESCRIPTION
Hi, this PR fixes compatibility issue with **python-socketio** server by implementing missing probe request/response handshake as described in the [protocol upgrade documentation](https://socket.io/docs/v4/engine-io-protocol/#upgrade).