### PR TITLE
Fix #422/unobserved task scheduler ex

### DIFF
--- a/src/SocketIOClient/Infrastructure/IErrorStrategy.cs
+++ b/src/SocketIOClient/Infrastructure/IErrorStrategy.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading.Tasks;
+
+namespace SocketIOClient.Infrastructure;
+
+public interface IErrorStrategy
+{
+    Task OnErrorAsync(AggregateException ex);
+}

--- a/src/SocketIOClient/Infrastructure/NoOpErrorStrategy.cs
+++ b/src/SocketIOClient/Infrastructure/NoOpErrorStrategy.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace SocketIOClient.Infrastructure;
+
+public class NoOpErrorStrategy : IErrorStrategy
+{
+    public Task OnErrorAsync(AggregateException _)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/SocketIOClient/Infrastructure/TaskExtensions.cs
+++ b/src/SocketIOClient/Infrastructure/TaskExtensions.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace SocketIOClient.Infrastructure;
+
+public static class TaskExtensions
+{
+    public static void FireAndForget(this Task task, IErrorStrategy errorStrategy)
+    {
+        _ = task
+            .ContinueWith(async t => await errorStrategy.OnErrorAsync(t.Exception!), TaskContinuationOptions.OnlyOnFaulted)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/SocketIOClient/Protocol/WebSocket/IWebSocketAdapter.cs
+++ b/src/SocketIOClient/Protocol/WebSocket/IWebSocketAdapter.cs
@@ -7,6 +7,7 @@ namespace SocketIOClient.Protocol.WebSocket;
 
 public interface IWebSocketAdapter : IProtocolAdapter
 {
+    bool HasListenerStarted { get; }
     Task ConnectAsync(Uri uri, CancellationToken cancellationToken);
     Task SendAsync(ProtocolMessage message, CancellationToken cancellationToken);
     Task CloseAsync(CancellationToken cancellationToken);

--- a/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
+++ b/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
@@ -16,6 +16,8 @@ public class WebSocketAdapter(
 {
     private readonly CancellationTokenSource _receiveCancellationTokenSource = new();
 
+    public bool HasListenerStarted { get; private set; }
+
     public async Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
     {
         await clientAdapter.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
@@ -46,6 +48,7 @@ public class WebSocketAdapter(
                 }
 
                 await OnNextAsync(protocolMessage).ConfigureAwait(false);
+                HasListenerStarted = true;
             }
             catch (Exception e)
             {

--- a/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
+++ b/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
@@ -16,8 +16,7 @@ public class WebSocketAdapter(ILogger<WebSocketAdapter> logger, IWebSocketClient
     {
         await clientAdapter.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
         var token = _receiveCancellationTokenSource.Token;
-        // must either be awaited or ReceiveAsync must not throw
-        await ReceiveAsync(token).ConfigureAwait(false);
+        _ = ReceiveAsync(token).ConfigureAwait(false);
     }
 
     private async Task ReceiveAsync(CancellationToken cancellationToken)

--- a/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
+++ b/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
@@ -16,7 +16,9 @@ public class WebSocketAdapter(ILogger<WebSocketAdapter> logger, IWebSocketClient
     {
         await clientAdapter.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
         var token = _receiveCancellationTokenSource.Token;
-        _ = ReceiveAsync(token).ConfigureAwait(false);
+        _ = ReceiveAsync(token)
+            .ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted)
+            .ConfigureAwait(false);
     }
 
     private async Task ReceiveAsync(CancellationToken cancellationToken)

--- a/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
+++ b/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
@@ -16,7 +16,8 @@ public class WebSocketAdapter(ILogger<WebSocketAdapter> logger, IWebSocketClient
     {
         await clientAdapter.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
         var token = _receiveCancellationTokenSource.Token;
-        _ = ReceiveAsync(token).ConfigureAwait(false);
+        // must either be awaited or ReceiveAsync must not throw
+        await ReceiveAsync(token).ConfigureAwait(false);
     }
 
     private async Task ReceiveAsync(CancellationToken cancellationToken)

--- a/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
+++ b/src/SocketIOClient/Protocol/WebSocket/WebSocketAdapter.cs
@@ -4,10 +4,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SocketIOClient.Common;
+using SocketIOClient.Infrastructure;
 
 namespace SocketIOClient.Protocol.WebSocket;
 
-public class WebSocketAdapter(ILogger<WebSocketAdapter> logger, IWebSocketClientAdapter clientAdapter)
+public class WebSocketAdapter(
+    ILogger<WebSocketAdapter> logger,
+    IWebSocketClientAdapter clientAdapter,
+    IErrorStrategy errorStrategy)
     : ProtocolAdapter, IWebSocketAdapter, IDisposable
 {
     private readonly CancellationTokenSource _receiveCancellationTokenSource = new();
@@ -16,9 +20,7 @@ public class WebSocketAdapter(ILogger<WebSocketAdapter> logger, IWebSocketClient
     {
         await clientAdapter.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
         var token = _receiveCancellationTokenSource.Token;
-        _ = ReceiveAsync(token)
-            .ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted)
-            .ConfigureAwait(false);
+        ReceiveAsync(token).FireAndForget(errorStrategy);
     }
 
     private async Task ReceiveAsync(CancellationToken cancellationToken)

--- a/src/SocketIOClient/ServicesInitializer.cs
+++ b/src/SocketIOClient/ServicesInitializer.cs
@@ -30,7 +30,8 @@ public static class ServicesInitializer
             .AddSingleton<IRetriable, RandomDelayRetryPolicy>()
             .AddSingleton<IEngineIOMessageAdapterFactory, EngineIOMessageAdapterFactory>()
             .AddSingleton<IDelay, TaskDelay>()
-            .AddSingleton<IEventRunner, EventRunner>();
+            .AddSingleton<IEventRunner, EventRunner>()
+            .AddSingleton<IErrorStrategy, NoOpErrorStrategy>();
 
         services
             .AddEngineIOCompatibility()

--- a/src/SocketIOClient/Session/EngineIOAdapter/EngineIO3Adapter.cs
+++ b/src/SocketIOClient/Session/EngineIOAdapter/EngineIO3Adapter.cs
@@ -93,7 +93,11 @@ public abstract class EngineIO3Adapter : IEngineIOAdapter, IDisposable
     private async Task StartPingAsync()
     {
         await OnPingTaskStarted().ConfigureAwait(false);
-        var token = _pingCancellationTokenSource.Token;
+
+        if (_pingCancellationTokenSource.IsCancellationRequested)
+            return;
+        var token = _pingCancellationTokenSource.Token; // .Token may throw ObjectDisposedException
+
         while (!token.IsCancellationRequested)
         {
             await _delay.DelayAsync(OpenedMessage!.PingInterval, token).ConfigureAwait(false);

--- a/src/SocketIOClient/Session/EngineIOAdapter/EngineIO3Adapter.cs
+++ b/src/SocketIOClient/Session/EngineIOAdapter/EngineIO3Adapter.cs
@@ -93,11 +93,7 @@ public abstract class EngineIO3Adapter : IEngineIOAdapter, IDisposable
     private async Task StartPingAsync()
     {
         await OnPingTaskStarted().ConfigureAwait(false);
-
-        if (_pingCancellationTokenSource.IsCancellationRequested)
-            return;
-        var token = _pingCancellationTokenSource.Token; // .Token may throw ObjectDisposedException
-
+        var token = _pingCancellationTokenSource.Token;
         while (!token.IsCancellationRequested)
         {
             await _delay.DelayAsync(OpenedMessage!.PingInterval, token).ConfigureAwait(false);

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -117,7 +117,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
         var ctsToken = cts.Token;
 
-        _ = ConnectCoreAsync(ctsToken).ConfigureAwait(false);
+        var taskConn = ConnectCoreAsync(ctsToken).ConfigureAwait(false);
         _logger.LogDebug("Waiting for socket.io connection result...");
         var task = Task.Run(async () => await _connCompletionSource.Task.ConfigureAwait(false), ctsToken);
         var ex = await task.ConfigureAwait(false);
@@ -127,6 +127,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
             _logger.LogDebug(ex.ToString());
             throw ex;
         }
+        await taskConn;
     }
 
     private async Task ConnectCoreAsync(CancellationToken cancellationToken)

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -117,7 +117,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
         var ctsToken = cts.Token;
 
-        var taskConn = ConnectCoreAsync(ctsToken).ConfigureAwait(false);
+        _ = ConnectCoreAsync(ctsToken).ConfigureAwait(false);
         _logger.LogDebug("Waiting for socket.io connection result...");
         var task = Task.Run(async () => await _connCompletionSource.Task.ConfigureAwait(false), ctsToken);
         var ex = await task.ConfigureAwait(false);
@@ -127,7 +127,6 @@ public class SocketIO : ISocketIO, IInternalSocketIO
             _logger.LogDebug(ex.ToString());
             throw ex;
         }
-        await taskConn;
     }
 
     private async Task ConnectCoreAsync(CancellationToken cancellationToken)

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -25,6 +25,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         _random = _serviceProvider.GetRequiredService<IRandom>();
         _delay = _serviceProvider.GetRequiredService<IDelay>();
         _eventRunner = _serviceProvider.GetRequiredService<IEventRunner>();
+        _errorStrategy = _serviceProvider.GetRequiredService<IErrorStrategy>();
     }
 
     public SocketIO(Uri uri, Action<IServiceCollection> configure) : this(uri, new SocketIOOptions(), configure)
@@ -42,6 +43,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
     private readonly IRandom _random;
     private readonly IDelay _delay;
     private readonly IEventRunner _eventRunner;
+    private readonly IErrorStrategy _errorStrategy;
     private readonly object _disconnectLock = new();
     private readonly object _ackHandlerLock = new();
 
@@ -117,9 +119,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
         var ctsToken = cts.Token;
 
-        _ = ConnectCoreAsync(ctsToken)
-            .ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted)
-            .ConfigureAwait(false);
+        ConnectCoreAsync(ctsToken).FireAndForget(_errorStrategy);
         _logger.LogDebug("Waiting for socket.io connection result...");
         var task = Task.Run(async () => await _connCompletionSource.Task.ConfigureAwait(false), ctsToken);
         var ex = await task.ConfigureAwait(false);

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -110,9 +110,9 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         }
 
         using var timeoutCts = new CancellationTokenSource(timeout);
-        timeoutCts.Token.Register(() => _connCompletionSource.TrySetResult(new TimeoutException()));
+        timeoutCts.Token.Register(() => _connCompletionSource.SetResult(new TimeoutException()));
 
-        cancellationToken.Register(() => _connCompletionSource.TrySetResult(new TaskCanceledException()));
+        cancellationToken.Register(() => _connCompletionSource.SetResult(new TaskCanceledException()));
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
         var ctsToken = cts.Token;
@@ -174,7 +174,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         _logger.LogDebug("Session connecting...");
         await session.ConnectAsync(cancellationToken).ConfigureAwait(false);
         _session = session;
-        _sessionCompletionSource!.TrySetResult(true);
+        _sessionCompletionSource!.SetResult(true);
         _logger.LogDebug("Session connected");
     }
 
@@ -188,7 +188,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         }
         catch (Exception ex)
         {
-            _connCompletionSource!.TrySetResult(ex);
+            _connCompletionSource!.SetResult(ex);
             throw;
         }
 

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -117,7 +117,9 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
         var ctsToken = cts.Token;
 
-        _ = ConnectCoreAsync(ctsToken).ConfigureAwait(false);
+        _ = ConnectCoreAsync(ctsToken)
+            .ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted)
+            .ConfigureAwait(false);
         _logger.LogDebug("Waiting for socket.io connection result...");
         var task = Task.Run(async () => await _connCompletionSource.Task.ConfigureAwait(false), ctsToken);
         var ex = await task.ConfigureAwait(false);

--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -110,9 +110,9 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         }
 
         using var timeoutCts = new CancellationTokenSource(timeout);
-        timeoutCts.Token.Register(() => _connCompletionSource.SetResult(new TimeoutException()));
+        timeoutCts.Token.Register(() => _connCompletionSource.TrySetResult(new TimeoutException()));
 
-        cancellationToken.Register(() => _connCompletionSource.SetResult(new TaskCanceledException()));
+        cancellationToken.Register(() => _connCompletionSource.TrySetResult(new TaskCanceledException()));
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
         var ctsToken = cts.Token;
@@ -174,7 +174,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         _logger.LogDebug("Session connecting...");
         await session.ConnectAsync(cancellationToken).ConfigureAwait(false);
         _session = session;
-        _sessionCompletionSource!.SetResult(true);
+        _sessionCompletionSource!.TrySetResult(true);
         _logger.LogDebug("Session connected");
     }
 
@@ -188,7 +188,7 @@ public class SocketIO : ISocketIO, IInternalSocketIO
         }
         catch (Exception ex)
         {
-            _connCompletionSource!.SetResult(ex);
+            _connCompletionSource!.TrySetResult(ex);
             throw;
         }
 

--- a/tests/SocketIOClient.UnitTests/Infrastructure/TaskExtensionsTests.cs
+++ b/tests/SocketIOClient.UnitTests/Infrastructure/TaskExtensionsTests.cs
@@ -1,0 +1,31 @@
+using NSubstitute;
+using SocketIOClient.Infrastructure;
+
+namespace SocketIOClient.UnitTests.Infrastructure;
+
+public class TaskExtensionsTests
+{
+    [Fact]
+    public async Task FireAndForget_TaskDoesNotThrow_ErrorStrategyNotCalled()
+    {
+        var strategy = Substitute.For<IErrorStrategy>();
+
+        var task = Task.CompletedTask;
+        task.FireAndForget(strategy);
+        await Task.Delay(200);
+
+        await strategy.DidNotReceive().OnErrorAsync(Arg.Any<AggregateException>());
+    }
+
+    [Fact]
+    public async Task FireAndForget_TaskThrows_ErrorStrategyWasCalled()
+    {
+        var strategy = Substitute.For<IErrorStrategy>();
+
+        var task = Task.FromException(new Exception("Boom"));
+        task.FireAndForget(strategy);
+        await Task.Delay(200);
+
+        await strategy.Received().OnErrorAsync(Arg.Any<AggregateException>());
+    }
+}

--- a/tests/SocketIOClient.UnitTests/Protocol/WebSocket/WebSocketAdapterTests.cs
+++ b/tests/SocketIOClient.UnitTests/Protocol/WebSocket/WebSocketAdapterTests.cs
@@ -140,6 +140,21 @@ public class WebSocketAdapterTests
         await observer.DidNotReceive().OnNextAsync(Arg.Any<ProtocolMessage>());
     }
 
+    private async Task WaitUntilListenerStartedAsync()
+    {
+        const int delay = 20;
+        for (var i = 0; i < 500; i++)
+        {
+            if (_wsAdapter.HasListenerStarted)
+            {
+                return;
+            }
+
+            await Task.Delay(delay);
+        }
+        throw new TimeoutException();
+    }
+
     [Fact]
     public async Task ConnectAsync_ReceivedTextMessage_NotifyToObserver()
     {
@@ -157,8 +172,7 @@ public class WebSocketAdapterTests
             });
 
         await _wsAdapter.ConnectAsync(new Uri("ws://127.0.0.1:1234"), CancellationToken.None);
-
-        await Task.Delay(400).ConfigureAwait(false);
+        await WaitUntilListenerStartedAsync();
 
         await observer.Received()
             .OnNextAsync(Arg.Is<ProtocolMessage>(m =>

--- a/tests/SocketIOClient.UnitTests/Protocol/WebSocket/WebSocketAdapterTests.cs
+++ b/tests/SocketIOClient.UnitTests/Protocol/WebSocket/WebSocketAdapterTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NSubstitute.ReceivedExtensions;
 using SocketIOClient.Common;
+using SocketIOClient.Infrastructure;
 using SocketIOClient.Observers;
 using SocketIOClient.Protocol.WebSocket;
 using SocketIOClient.Test.Core;
@@ -18,7 +19,8 @@ public class WebSocketAdapterTests
         var logger = output.CreateLogger<WebSocketAdapter>();
         _clientAdapter = Substitute.For<IWebSocketClientAdapter>();
         _onDisconnect = Substitute.For<Action>();
-        _wsAdapter = new WebSocketAdapter(logger, _clientAdapter)
+        _errorStrategy = Substitute.For<IErrorStrategy>();
+        _wsAdapter = new WebSocketAdapter(logger, _clientAdapter, _errorStrategy)
         {
             OnDisconnected = _onDisconnect
         };
@@ -26,6 +28,7 @@ public class WebSocketAdapterTests
 
     private readonly WebSocketAdapter _wsAdapter;
     private readonly IWebSocketClientAdapter _clientAdapter;
+    private readonly IErrorStrategy _errorStrategy;
     private readonly Action _onDisconnect;
 
     [Fact]
@@ -288,21 +291,15 @@ public class WebSocketAdapterTests
     }
 
     [Fact]
-    public async Task ReceiveAsync_ThrowInBackground_NoUnobservedTaskExceptions()
+    public async Task ReceiveAsync_ThrowInBackground_ErrorStrategyWasUsed()
     {
-        var exceptions = new List<Exception>();
-        TaskScheduler.UnobservedTaskException += (_, e) => { exceptions.Add(e.Exception); };
-
         _clientAdapter.ReceiveAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Boom"));
 
         await _wsAdapter.ConnectAsync(new Uri("ws://127.0.0.1:1234"), CancellationToken.None);
 
         await Task.Delay(200).ConfigureAwait(false);
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
 
-        exceptions.Should().BeEmpty();
+        await _errorStrategy.Received(1).OnErrorAsync(Arg.Any<AggregateException>());
     }
 }

--- a/tests/SocketIOClient.UnitTests/Protocol/WebSocket/WebSocketAdapterTests.cs
+++ b/tests/SocketIOClient.UnitTests/Protocol/WebSocket/WebSocketAdapterTests.cs
@@ -286,4 +286,23 @@ public class WebSocketAdapterTests
 
         await _clientAdapter.Received(1).CloseAsync(token);
     }
+
+    [Fact]
+    public async Task ReceiveAsync_ThrowInBackground_NoUnobservedTaskExceptions()
+    {
+        var exceptions = new List<Exception>();
+        TaskScheduler.UnobservedTaskException += (_, e) => { exceptions.Add(e.Exception); };
+
+        _clientAdapter.ReceiveAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Boom"));
+
+        await _wsAdapter.ConnectAsync(new Uri("ws://127.0.0.1:1234"), CancellationToken.None);
+
+        await Task.Delay(200).ConfigureAwait(false);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        exceptions.Should().BeEmpty();
+    }
 }

--- a/tests/SocketIOClient.UnitTests/SocketIOTests.cs
+++ b/tests/SocketIOClient.UnitTests/SocketIOTests.cs
@@ -51,6 +51,21 @@ public class SocketIOTests
             },
         };
     }
+    private SocketIO NewSocketIO(Uri url, SocketIOOptions customOptions)
+    {
+        return new SocketIO(url, customOptions, services =>
+        {
+            services.AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Trace);
+                builder.AddProvider(new XUnitLoggerProvider(_output));
+            });
+            services.Replace(ServiceDescriptor.KeyedScoped(TransportProtocol.Polling, (_, _) => _session));
+            services.Replace(ServiceDescriptor.KeyedScoped(TransportProtocol.WebSocket, (_, _) => _wsSession));
+            services.Replace(ServiceDescriptor.Singleton(_random));
+            services.Replace(ServiceDescriptor.Singleton(_eventRunner));
+        });
+    }
 
     private readonly SocketIO _io;
     private readonly ISession _session;
@@ -402,6 +417,90 @@ public class SocketIOTests
         await _session.Received().SendAsync(Arg.Any<object[]>(), CancellationToken.None);
     }
 
+    /// <summary>
+    /// Test if ConnectAsync's _connCompletionSource can throw because of .SetResult being called multiple times
+    /// 
+    /// Bug: _connCompletionSource uses SetResult in multiple competing locations:
+    ///   1. timeoutCts.Token.Register  -> fires at ConnectionTimeout * 1.02        -> .SetResult
+    ///   2. cancellationToken.Register -> fires when caller's token is cancelled   -> .SetResult
+    /// 
+    /// Fix: replace all SetResult calls on _connCompletionSource with TrySetResult.
+    /// </summary>
+    [Fact]
+    public async Task ConnectAsync_NoUnobservedTaskSchedulerExceptions()
+    {
+        var unobservedConnectionExceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+        EventHandler<UnobservedTaskExceptionEventArgs> unobservedHandler = (_, e) =>
+        {
+            // Filter out false positives that are unrelated to the SetResult race bug:
+            //   - xunit TestOutputHelper throws when logging after the test context ends
+            static bool IsFalsePositive(Exception ex)
+            {
+                if (ex is AggregateException agg)
+                    return agg.InnerExceptions.All(IsFalsePositive);
+                return (ex is InvalidOperationException && ex.Message.Contains("There is no currently active test"));
+            }
+
+            if (IsFalsePositive(e.Exception))
+            {
+                e.SetObserved();
+                return;
+            }
+
+            try
+            {
+                _output.WriteLine($">> Unobserved exception: {e.Exception}");
+                unobservedConnectionExceptions.Add(e.Exception);
+                e.SetObserved();
+            } catch (Exception) {} // ignore any exception from logging
+        };
+        TaskScheduler.UnobservedTaskException += unobservedHandler;
+
+        try
+        {
+            int timeout = 1; // socket io timeout
+            int timeout2 = (int)(timeout * 1.02); // timeoutCts fires at this time
+
+            // Build socket io instance
+            SocketIOOptions opts = new SocketIOOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(timeout),
+                Reconnection = false
+            };
+            SocketIO sio = NewSocketIO(new Uri("https://unresolvable.invalid:3443"), opts);
+
+            // Run many iterations to maximize the chance of hitting the race window
+            for (int i = 0; i < 300; i++)
+            {
+                try
+                {
+                    // Cancel at the same time the connection is expected to fail,
+                    // so cancellationToken.Register and ConnectCoreAsync.SetResult race
+                    using var cts = new CancellationTokenSource(timeout2);
+                    await _io.ConnectAsync(cts.Token);
+                }
+                catch (Exception ex) when (ex is TaskCanceledException or ConnectionException or TimeoutException) {
+                    // All of these are expected outcomes — only InvalidOperationException is the bug
+                }
+                if (unobservedConnectionExceptions.Count > 0)
+                    break; // error recreated
+            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            await Task.Delay(200);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= unobservedHandler;
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        await Task.Delay(1000);
+
+        unobservedConnectionExceptions.Should().BeEmpty("because no exception should be thrown from ConnectAsync's _connCompletionSource");
+
+    }
     #endregion
 
     #region Private Methods

--- a/tests/SocketIOClient.UnitTests/SocketIOTests.cs
+++ b/tests/SocketIOClient.UnitTests/SocketIOTests.cs
@@ -51,21 +51,6 @@ public class SocketIOTests
             },
         };
     }
-    private SocketIO NewSocketIO(Uri url, SocketIOOptions customOptions)
-    {
-        return new SocketIO(url, customOptions, services =>
-        {
-            services.AddLogging(builder =>
-            {
-                builder.SetMinimumLevel(LogLevel.Trace);
-                builder.AddProvider(new XUnitLoggerProvider(_output));
-            });
-            services.Replace(ServiceDescriptor.KeyedScoped(TransportProtocol.Polling, (_, _) => _session));
-            services.Replace(ServiceDescriptor.KeyedScoped(TransportProtocol.WebSocket, (_, _) => _wsSession));
-            services.Replace(ServiceDescriptor.Singleton(_random));
-            services.Replace(ServiceDescriptor.Singleton(_eventRunner));
-        });
-    }
 
     private readonly SocketIO _io;
     private readonly ISession _session;
@@ -417,89 +402,29 @@ public class SocketIOTests
         await _session.Received().SendAsync(Arg.Any<object[]>(), CancellationToken.None);
     }
 
-    /// <summary>
-    /// Test if ConnectAsync's _connCompletionSource can throw because of .SetResult being called multiple times
-    /// 
-    /// Bug: _connCompletionSource uses SetResult in multiple competing locations:
-    ///   1. timeoutCts.Token.Register  -> fires at ConnectionTimeout * 1.02        -> .SetResult
-    ///   2. cancellationToken.Register -> fires when caller's token is cancelled   -> .SetResult
-    /// 
-    /// Fix: replace all SetResult calls on _connCompletionSource with TrySetResult.
-    /// </summary>
     [Fact]
-    public async Task ConnectAsync_NoUnobservedTaskSchedulerExceptions()
+    public async Task ConnectAsync_ThrowInBackground_NoUnobservedTaskExceptions()
     {
-        var unobservedConnectionExceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
-        EventHandler<UnobservedTaskExceptionEventArgs> unobservedHandler = (_, e) =>
+        var exceptions = new List<Exception>();
+        TaskScheduler.UnobservedTaskException += (_, e) =>
         {
-            // Filter out false positives that are unrelated to the SetResult race bug:
-            //   - xunit TestOutputHelper throws when logging after the test context ends
-            static bool IsFalsePositive(Exception ex)
-            {
-                if (ex is AggregateException agg)
-                    return agg.InnerExceptions.All(IsFalsePositive);
-                return (ex is InvalidOperationException && ex.Message.Contains("There is no currently active test"));
-            }
-
-            if (IsFalsePositive(e.Exception))
-            {
-                e.SetObserved();
-                return;
-            }
-
-            try
-            {
-                _output.WriteLine($">> Unobserved exception: {e.Exception}");
-                unobservedConnectionExceptions.Add(e.Exception);
-                e.SetObserved();
-            } catch (Exception) {} // ignore any exception from logging
+            exceptions.Add(e.Exception);
         };
-        TaskScheduler.UnobservedTaskException += unobservedHandler;
 
-        try
-        {
-            int timeout = 1; // socket io timeout
-            int timeout2 = (int)(timeout * 1.02); // timeoutCts fires at this time
+        _io.Options.Reconnection = true;
+        _io.Options.ReconnectionAttempts = 2;
+        _session.ConnectAsync(Arg.Any<CancellationToken>()).Throws(new Exception("Test"));
+        await _io
+            .Invoking(async x => await x.ConnectAsync())
+            .Should()
+            .ThrowAsync<ConnectionException>();
 
-            // Build socket io instance
-            SocketIOOptions opts = new SocketIOOptions
-            {
-                ConnectionTimeout = TimeSpan.FromMilliseconds(timeout),
-                Reconnection = false
-            };
-            SocketIO sio = NewSocketIO(new Uri("https://unresolvable.invalid:3443"), opts);
-
-            // Run many iterations to maximize the chance of hitting the race window
-            for (int i = 0; i < 300; i++)
-            {
-                try
-                {
-                    // Cancel at the same time the connection is expected to fail,
-                    // so cancellationToken.Register and ConnectCoreAsync.SetResult race
-                    using var cts = new CancellationTokenSource(timeout2);
-                    await _io.ConnectAsync(cts.Token);
-                }
-                catch (Exception ex) when (ex is TaskCanceledException or ConnectionException or TimeoutException) {
-                    // All of these are expected outcomes — only InvalidOperationException is the bug
-                }
-                if (unobservedConnectionExceptions.Count > 0)
-                    break; // error recreated
-            }
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            await Task.Delay(200);
-        }
-        finally
-        {
-            TaskScheduler.UnobservedTaskException -= unobservedHandler;
-        }
-
+        await Task.Delay(200);
         GC.Collect();
         GC.WaitForPendingFinalizers();
-        await Task.Delay(1000);
+        GC.Collect();
 
-        unobservedConnectionExceptions.Should().BeEmpty("because no exception should be thrown from ConnectAsync's _connCompletionSource");
-
+        exceptions.Should().BeEmpty();
     }
     #endregion
 

--- a/tests/SocketIOClient.UnitTests/SocketIOTests.cs
+++ b/tests/SocketIOClient.UnitTests/SocketIOTests.cs
@@ -25,6 +25,7 @@ public class SocketIOTests
         _wsSession = Substitute.For<ISession>();
         _random = Substitute.For<IRandom>();
         _eventRunner = Substitute.For<IEventRunner>();
+        _errorStrategy = Substitute.For<IErrorStrategy>();
         _output = output;
         _io = NewSocketIO(new Uri("http://localhost:3000"));
     }
@@ -42,6 +43,7 @@ public class SocketIOTests
             services.Replace(ServiceDescriptor.KeyedScoped(TransportProtocol.WebSocket, (_, _) => _wsSession));
             services.Replace(ServiceDescriptor.Singleton(_random));
             services.Replace(ServiceDescriptor.Singleton(_eventRunner));
+            services.Replace(ServiceDescriptor.Singleton(_errorStrategy));
         })
         {
             Options =
@@ -57,6 +59,7 @@ public class SocketIOTests
     private readonly ISession _wsSession;
     private readonly IRandom _random;
     private readonly IEventRunner _eventRunner;
+    private readonly IErrorStrategy _errorStrategy;
     private readonly ITestOutputHelper _output;
 
     [Fact]
@@ -403,28 +406,17 @@ public class SocketIOTests
     }
 
     [Fact]
-    public async Task ConnectAsync_ThrowInBackground_NoUnobservedTaskExceptions()
+    public async Task ConnectAsync_ThrowInBackground_ErrorStrategyWasUsed()
     {
-        var exceptions = new List<Exception>();
-        TaskScheduler.UnobservedTaskException += (_, e) =>
-        {
-            exceptions.Add(e.Exception);
-        };
-
         _io.Options.Reconnection = true;
-        _io.Options.ReconnectionAttempts = 2;
-        _session.ConnectAsync(Arg.Any<CancellationToken>()).Throws(new Exception("Test"));
+        _io.Options.ReconnectionAttempts = 5;
+        _session.ConnectAsync(Arg.Any<CancellationToken>()).Throws(new Exception("Boom"));
         await _io
             .Invoking(async x => await x.ConnectAsync())
             .Should()
             .ThrowAsync<ConnectionException>();
 
-        await Task.Delay(200);
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
-        exceptions.Should().BeEmpty();
+        await _errorStrategy.Received(1).OnErrorAsync(Arg.Any<AggregateException>());
     }
     #endregion
 


### PR DESCRIPTION
Hello, 
I added a test to look for unobserved TaskScheduler exceptions, and I made a few changes until all tests passed:

1. Added the test and an overload for NewSocketIO with custom options in tests\SocketIOClient.UnitTests\SocketIOTests.cs
2. Replaced .SetResult with .TrySetResult for an edge case (demonstrated by the test, which will fail with .SetResult)
3. awaited the result of ConnectCoreAsync in ConnectAsync (#422)
4. awaited the result of ReceiveAsync in src\SocketIOClient\Protocol\WebSocket\WebSocketAdapter.cs
5. added CTS disposed check in src\SocketIOClient\Session\EngineIOAdapter\EngineIO3Adapter.cs

Please check that I did not cause any unexpected problems with these changes, all tests are passing. Each of these changes can be verified with the ConnectAsync_NoUnobservedTaskSchedulerExceptions test 