### PR TITLE
docs: clarify WebSocketOptions namespace to avoid conflict with System.Net.WebSockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,9 @@ var client = new SocketIO(new Uri("http://localhost:11400"), services =>
     });
 });
 ```
-
-> Note: By default, the client communicates with the server using polling first. If the server supports WebSocket, the connection will be upgraded to a WebSocket channel. In this scenario, you may need to configure CertificateValidationCallback for both transports.
+> **Notes:**
+> - By default, the client communicates with the server using polling first. If the server supports WebSocket, the connection will be upgraded to a WebSocket channel. In this scenario, you may need to configure CertificateValidationCallback for both transports.
+> - `WebSocketOptions` also exists in `System.Net.WebSockets` (.NET), which does not have a `RemoteCertificateValidationCallback` property and will cause a compile error. Make sure you're using `SocketIOClient.Protocol.WebSocket.WebSocketOptions`, either via an explicit `using SocketIOClient.Protocol.WebSocket;` or by using the fully qualified name.
 
 ## Proxy
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -236,7 +236,9 @@ var client = new SocketIO(new Uri("http://localhost:11400"), services =>
 });
 ```
 
-> 注意：默认情况下优先使用 Polling 与服务端通信，如果服务端支持 WebSocket，则会升级到 WebSocket 信道，在这种场景下，你可能需要同时为两者配置 CertificateValidationCallback
+> **注意：**
+> - 默认情况下优先使用 Polling 与服务端通信，如果服务端支持 WebSocket，则会升级到 WebSocket 信道，在这种场景下，你可能需要同时为两者配置 CertificateValidationCallback
+> - `WebSocketOptions` 在 .NET 的 `System.Net.WebSockets` 命名空间中也存在，但该类型没有 `RemoteCertificateValidationCallback` 属性，使用错误会导致编译错误。请确保使用的是 `SocketIOClient.Protocol.WebSocket.WebSocketOptions`，可以通过显式 `using SocketIOClient.Protocol.WebSocket;` 或使用完全限定名来避免冲突。
 
 ## 代理
 


### PR DESCRIPTION
While working on a project using this package, I ran into an issue where RemoteCertificateValidationCallback wasn't being recognized. Turns out I was accidentally using System.Net.WebSockets.WebSocketOptions instead of the package's own SocketIOClient.Protocol.WebSocket.WebSocketOptions. Both types share the same name, which makes the mistake easy to miss, especially since the compiler error points to a missing property rather than a wrong namespace.
Added a note in both READMEs (English and Chinese) to help others avoid the same confusion. Relates to #417.